### PR TITLE
feat: check if build.zig and zbuild.zon are sync'ed in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,9 +29,9 @@ jobs:
           sudo cp zig-out/bin/zbuild /usr/local/bin/zbuild
 
       - name: Verify zbuild
-        run: zbuild --version
+        run: zbuild version
 
-      - name: Check if build.zig is out of sync
+      - name: Check if build.zig is sync'ed with zbuild.zon
         run: |
           zbuild sync
           git diff --exit-code

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,33 @@ on:
       - main
 
 jobs:
+  zbuild: 
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: "0.14.0"
+
+      - name: Install zbuild
+        run: |
+          git clone https://github.com/ChainSafe/zbuild.git
+          cd zbuild
+          zig build -Doptimize=ReleaseFast
+          sudo cp zig-out/bin/zbuild /usr/local/bin/zbuild
+
+      - name: Verify zbuild
+        run: zbuild --version
+
+      - name: Check if build.zig is out of sync
+        run: |
+          zbuild sync
+          git diff --exit-code
+
   zig-build-upload:
     strategy:
       matrix:

--- a/build.zig
+++ b/build.zig
@@ -118,4 +118,6 @@ pub fn build(b: *std.Build) void {
 
     module_consensus_types.addImport("build_options", options_module_build_options);
     module_consensus_types.addImport("ssz", dep_ssz.module("ssz"));
+
+    module_download_spec_tests.addImport("spec_test_options", options_module_spec_test_options);
 }

--- a/build.zig
+++ b/build.zig
@@ -118,6 +118,4 @@ pub fn build(b: *std.Build) void {
 
     module_consensus_types.addImport("build_options", options_module_build_options);
     module_consensus_types.addImport("ssz", dep_ssz.module("ssz"));
-
-    module_download_spec_tests.addImport("spec_test_options", options_module_spec_test_options);
 }


### PR DESCRIPTION
CI will run `zbuild sync` to make sure `build.zig` and `zbuild.zon` are sync'ed.

Example of failed run https://github.com/ChainSafe/state-transition-z/actions/runs/18160134738/job/51688888127?pr=52

