### PR TITLE
expose shuffle for lodestar-bun

### DIFF
--- a/src/state_transition/root.zig
+++ b/src/state_transition/root.zig
@@ -11,6 +11,8 @@ pub const EpochCacheRc = @import("./cache/epoch_cache.zig").EpochCacheRc;
 pub const EpochCache = @import("./cache/epoch_cache.zig").EpochCache;
 
 pub const PubkeyIndexMap = @import("./utils/pubkey_index_map.zig").PubkeyIndexMap;
+pub const shuffle = @import("./utils/shuffle.zig");
+pub const committee_indices = @import("./utils/committee_indices.zig");
 pub const Index2PubkeyCache = @import("./cache/pubkey_cache.zig").Index2PubkeyCache;
 pub const syncPubkeys = @import("./cache/pubkey_cache.zig").syncPubkeys;
 


### PR DESCRIPTION
Exposing ` shuffle` and `committee_indices` for use in https://github.com/ChainSafe/lodestar-bun/pull/20.