### PR TITLE
chore: deduplicate SignedBeaconBlockHeader and reuse the type from phase0

### DIFF
--- a/src/consensus_types/altair.zig
+++ b/src/consensus_types/altair.zig
@@ -17,6 +17,7 @@ pub const HistoricalBatch = phase0.HistoricalBatch;
 pub const DepositMessage = phase0.DepositMessage;
 pub const DepositData = phase0.DepositData;
 pub const BeaconBlockHeader = phase0.BeaconBlockHeader;
+pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 pub const SigningData = phase0.SigningData;
 pub const ProposerSlashing = phase0.ProposerSlashing;
 pub const AttesterSlashing = phase0.AttesterSlashing;
@@ -34,7 +35,6 @@ pub const AttesterSlashings = phase0.AttesterSlashings;
 pub const Attestations = phase0.Attestations;
 pub const Deposits = phase0.Deposits;
 pub const VoluntaryExits = phase0.VoluntaryExits;
-pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 
 pub const SyncAggregate = ssz.FixedContainerType(struct {
     sync_committee_bits: ssz.BitVectorType(preset.SYNC_COMMITTEE_SIZE),

--- a/src/consensus_types/bellatrix.zig
+++ b/src/consensus_types/bellatrix.zig
@@ -18,6 +18,7 @@ pub const HistoricalBatch = phase0.HistoricalBatch;
 pub const DepositMessage = phase0.DepositMessage;
 pub const DepositData = phase0.DepositData;
 pub const BeaconBlockHeader = phase0.BeaconBlockHeader;
+pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 pub const SigningData = phase0.SigningData;
 pub const ProposerSlashing = phase0.ProposerSlashing;
 pub const AttesterSlashing = phase0.AttesterSlashing;
@@ -35,7 +36,6 @@ pub const AttesterSlashings = phase0.AttesterSlashings;
 pub const Attestations = phase0.Attestations;
 pub const Deposits = phase0.Deposits;
 pub const VoluntaryExits = phase0.VoluntaryExits;
-pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 
 pub const SyncAggregate = altair.SyncAggregate;
 pub const SyncCommittee = altair.SyncCommittee;

--- a/src/consensus_types/capella.zig
+++ b/src/consensus_types/capella.zig
@@ -19,6 +19,7 @@ pub const HistoricalBatch = phase0.HistoricalBatch;
 pub const DepositMessage = phase0.DepositMessage;
 pub const DepositData = phase0.DepositData;
 pub const BeaconBlockHeader = phase0.BeaconBlockHeader;
+pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 pub const SigningData = phase0.SigningData;
 pub const ProposerSlashing = phase0.ProposerSlashing;
 pub const AttesterSlashing = phase0.AttesterSlashing;
@@ -36,7 +37,6 @@ pub const AttesterSlashings = phase0.AttesterSlashings;
 pub const Attestations = phase0.Attestations;
 pub const Deposits = phase0.Deposits;
 pub const VoluntaryExits = phase0.VoluntaryExits;
-pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 
 pub const SyncAggregate = altair.SyncAggregate;
 pub const SyncCommittee = altair.SyncCommittee;

--- a/src/consensus_types/deneb.zig
+++ b/src/consensus_types/deneb.zig
@@ -20,6 +20,7 @@ pub const HistoricalBatch = phase0.HistoricalBatch;
 pub const DepositMessage = phase0.DepositMessage;
 pub const DepositData = phase0.DepositData;
 pub const BeaconBlockHeader = phase0.BeaconBlockHeader;
+pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 pub const SigningData = phase0.SigningData;
 pub const ProposerSlashing = phase0.ProposerSlashing;
 pub const AttesterSlashing = phase0.AttesterSlashing;
@@ -37,7 +38,6 @@ pub const AttesterSlashings = phase0.AttesterSlashings;
 pub const Attestations = phase0.Attestations;
 pub const Deposits = phase0.Deposits;
 pub const VoluntaryExits = phase0.VoluntaryExits;
-pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 
 pub const SyncAggregate = altair.SyncAggregate;
 pub const SyncCommittee = altair.SyncCommittee;

--- a/src/consensus_types/electra.zig
+++ b/src/consensus_types/electra.zig
@@ -20,6 +20,7 @@ pub const HistoricalBatch = phase0.HistoricalBatch;
 pub const DepositMessage = phase0.DepositMessage;
 pub const DepositData = phase0.DepositData;
 pub const BeaconBlockHeader = phase0.BeaconBlockHeader;
+pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 pub const SigningData = phase0.SigningData;
 pub const ProposerSlashing = phase0.ProposerSlashing;
 pub const Deposit = phase0.Deposit;
@@ -32,7 +33,6 @@ pub const ProposerSlashings = phase0.ProposerSlashings;
 pub const AttesterSlashings = ssz.VariableListType(AttesterSlashing, preset.MAX_ATTESTER_SLASHINGS_ELECTRA);
 pub const Deposits = phase0.Deposits;
 pub const VoluntaryExits = phase0.VoluntaryExits;
-pub const SignedBeaconBlockHeader = phase0.SignedBeaconBlockHeader;
 
 pub const SyncAggregate = altair.SyncAggregate;
 pub const SyncCommittee = altair.SyncCommittee;


### PR DESCRIPTION
Those files redefined the same type `SignedBeaconBlockHeader` where already defined in `phase0.zig`. So this PR remove the redefinition and re-export the type from phase0. 

- `altair.zig`
- `bellatrix.zig`
- `capella.zig`
- `deneb.zig`
- `electra.zig`

close #42 