### PR TITLE
feat: add mutable view check

### DIFF
--- a/src/ssz/type/type_kind.zig
+++ b/src/ssz/type/type_kind.zig
@@ -30,3 +30,24 @@ pub fn isFixedType(T: type) bool {
         },
     };
 }
+
+/// Determines if the TreeView of this type is mutable.
+/// Returns false for:
+/// - Any BasicType (uint, bool)
+/// - ByteVector, ByteList
+/// All other composite types return TreeView wrappers that can be modified.
+pub fn isViewMutable(comptime ST: type) bool {
+    if (isBasicType(ST)) {
+        return false;
+    }
+
+    if (ST.kind == .list or ST.kind == .vector) {
+        if (@hasDecl(ST, "Element")) {
+            const E = ST.Element;
+            if (E.kind == .uint and E.fixed_size == 1) {
+                return false;
+            }
+        }
+    }
+    return true;
+}


### PR DESCRIPTION
**Motivation**
Align TreeView's change tracking behavior with TypeScript's TreeViewDU implementation,  only mutable views are tracked in viewsChanged. 

**Description**
- Add `isViewMutable` function in type_kind.zig to determine if a type's TreeView is mutable
- Update `getElement` and `getField` in TreeView to conditionally mark elements as changed based on `isViewMutable`
- Add `getElementReadonly` function for List/Vector types