### PR TITLE
fix: remove mainnet spec tests from minimal spec test ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -172,9 +172,6 @@ jobs:
       - name: Run spec tests - minimal
         run: |
           zig build test:spec_tests -Dpreset=minimal
-      - name: Run spec tests - mainnet
-        run: |
-          zig build test:spec_tests -Dpreset=mainnet
 
   spec-test-mainnet:
     name: spec tests - mainnet


### PR DESCRIPTION
- fix bug in #150 

<img width="831" height="271" alt="Screenshot from 2025-12-31 17-43-44" src="https://github.com/user-attachments/assets/3dd10336-a19b-4af9-8c01-316906f86bb6" />
