### PR TITLE
refactor: mv `utils/finality.zig` to `epoch/inactivity_leak.zig`

### DIFF
--- a/src/state_transition/epoch/get_rewards_and_penalties.zig
+++ b/src/state_transition/epoch/get_rewards_and_penalties.zig
@@ -22,7 +22,7 @@ const FLAG_PREV_SOURCE_ATTESTER_UNSLASHED = attester_status.FLAG_PREV_SOURCE_ATT
 const FLAG_PREV_TARGET_ATTESTER_UNSLASHED = attester_status.FLAG_PREV_TARGET_ATTESTER_UNSLASHED;
 const hasMarkers = attester_status.hasMarkers;
 
-const isInInactivityLeak = @import("../utils/finality.zig").isInInactivityLeak;
+const isInInactivityLeak = @import("inactivity_leak.zig").isInInactivityLeak;
 
 const RewardPenaltyItem = struct {
     base_reward: u64,

--- a/src/state_transition/epoch/inactivity_leak.zig
+++ b/src/state_transition/epoch/inactivity_leak.zig
@@ -1,17 +1,9 @@
+//! Utility function to calculate if a validator is in "inactivity leak" mode.
 const std = @import("std");
 const CachedBeaconState = @import("../cache/state_cache.zig").CachedBeaconState;
 const preset = @import("preset").preset;
 const MIN_EPOCHS_TO_INACTIVITY_PENALTY = preset.MIN_EPOCHS_TO_INACTIVITY_PENALTY;
-const computePreviousEpoch = @import("./epoch.zig").computePreviousEpoch;
-
-pub fn getFinalityDelay(cached_state: *const CachedBeaconState) !u64 {
-    const previous_epoch = computePreviousEpoch(cached_state.getEpochCache().epoch);
-    const finalized_epoch = try cached_state.state.finalizedEpoch();
-    std.debug.assert(previous_epoch >= finalized_epoch);
-
-    // previous_epoch = epoch - 1
-    return previous_epoch - finalized_epoch;
-}
+const computePreviousEpoch = @import("../utils/epoch.zig").computePreviousEpoch;
 
 /// If the chain has not been finalized for >4 epochs, the chain enters an "inactivity leak" mode,
 /// where inactive validators get progressively penalized more and more, to reduce their influence
@@ -19,4 +11,13 @@ pub fn getFinalityDelay(cached_state: *const CachedBeaconState) !u64 {
 /// it works.
 pub fn isInInactivityLeak(state: *const CachedBeaconState) !bool {
     return (try getFinalityDelay(state)) > MIN_EPOCHS_TO_INACTIVITY_PENALTY;
+}
+
+fn getFinalityDelay(cached_state: *const CachedBeaconState) !u64 {
+    const previous_epoch = computePreviousEpoch(cached_state.getEpochCache().epoch);
+    const finalized_epoch = try cached_state.state.finalizedEpoch();
+    std.debug.assert(previous_epoch >= finalized_epoch);
+
+    // previous_epoch = epoch - 1
+    return previous_epoch - finalized_epoch;
 }

--- a/src/state_transition/epoch/process_inactivity_updates.zig
+++ b/src/state_transition/epoch/process_inactivity_updates.zig
@@ -3,7 +3,7 @@ const CachedBeaconState = @import("../cache/state_cache.zig").CachedBeaconState;
 
 const EpochTransitionCache = @import("../cache/epoch_transition_cache.zig").EpochTransitionCache;
 const GENESIS_EPOCH = @import("preset").GENESIS_EPOCH;
-const isInInactivityLeak = @import("../utils/finality.zig").isInInactivityLeak;
+const isInInactivityLeak = @import("inactivity_leak.zig").isInInactivityLeak;
 const attester_status_utils = @import("../utils/attester_status.zig");
 const hasMarkers = attester_status_utils.hasMarkers;
 


### PR DESCRIPTION
Part of #169

More straightforward naming.