### PR TITLE
feat(napi): metrics bindings

### DIFF
--- a/bindings/napi/metrics.zig
+++ b/bindings/napi/metrics.zig
@@ -11,14 +11,6 @@ else
 
 var initialized: bool = false;
 
-pub fn Metrics_init(env: napi.Env, _: napi.CallbackInfo(0)) !napi.Value {
-    if (!initialized) {
-        try state_transition.metrics.init(allocator, .{});
-        initialized = true;
-    }
-    return env.getUndefined();
-}
-
 pub fn Metrics_scrapeMetrics(env: napi.Env, _: napi.CallbackInfo(0)) !napi.Value {
     var buf = std.ArrayList(u8).init(allocator);
     defer buf.deinit();
@@ -34,12 +26,7 @@ pub fn deinit() void {
 
 pub fn register(env: napi.Env, exports: napi.Value) !void {
     const metrics_obj = try env.createObject();
-    try metrics_obj.setNamedProperty("init", try env.createFunction(
-        "init",
-        0,
-        Metrics_init,
-        null,
-    ));
+
     try metrics_obj.setNamedProperty("scrapeMetrics", try env.createFunction(
         "scrapeMetrics",
         0,

--- a/bindings/napi/metrics.zig
+++ b/bindings/napi/metrics.zig
@@ -1,0 +1,50 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const napi = @import("zapi:napi");
+const state_transition = @import("state_transition");
+
+var gpa: std.heap.DebugAllocator(.{}) = .init;
+const allocator = if (builtin.mode == .Debug)
+    gpa.allocator()
+else
+    std.heap.c_allocator;
+
+var initialized: bool = false;
+
+pub fn Metrics_init(env: napi.Env, _: napi.CallbackInfo(0)) !napi.Value {
+    if (!initialized) {
+        try state_transition.metrics.init(allocator, .{});
+        initialized = true;
+    }
+    return env.getUndefined();
+}
+
+pub fn Metrics_scrapeMetrics(env: napi.Env, _: napi.CallbackInfo(0)) !napi.Value {
+    var buf = std.ArrayList(u8).init(allocator);
+    defer buf.deinit();
+    try state_transition.metrics.write(buf.writer());
+    return env.createStringUtf8(buf.items);
+}
+
+pub fn deinit() void {
+    if (!initialized) return;
+    state_transition.metrics.state_transition.deinit();
+    initialized = false;
+}
+
+pub fn register(env: napi.Env, exports: napi.Value) !void {
+    const metrics_obj = try env.createObject();
+    try metrics_obj.setNamedProperty("init", try env.createFunction(
+        "init",
+        0,
+        Metrics_init,
+        null,
+    ));
+    try metrics_obj.setNamedProperty("scrapeMetrics", try env.createFunction(
+        "scrapeMetrics",
+        0,
+        Metrics_scrapeMetrics,
+        null,
+    ));
+    try exports.setNamedProperty("metrics", metrics_obj);
+}

--- a/bindings/napi/root.zig
+++ b/bindings/napi/root.zig
@@ -4,6 +4,7 @@ const pool = @import("./pool.zig");
 const pubkeys = @import("./pubkeys.zig");
 const config = @import("./config.zig");
 const shuffle = @import("./shuffle.zig");
+const metrics = @import("./metrics.zig");
 const BeaconStateView = @import("./BeaconStateView.zig");
 const blst = @import("./blst.zig");
 const state_transition = @import("./state_transition.zig");
@@ -24,6 +25,7 @@ const EnvCleanup = struct {
             config.state.deinit();
             pubkeys.state.deinit();
             pool.state.deinit();
+            metrics.deinit();
         }
     }
 };
@@ -47,4 +49,5 @@ fn register(env: napi.Env, exports: napi.Value) !void {
     try BeaconStateView.register(env, exports);
     try blst.register(env, exports);
     try state_transition.register(env, exports);
+    try metrics.register(env, exports);
 }

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -238,7 +238,7 @@ declare const bindings: {
   };
   metrics: {
     init: () => void;
-    scrapeMetrics: () => Uint8Array;
+    scrapeMetrics: () => string;
   };
   BeaconStateView: typeof BeaconStateView;
 };

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -236,6 +236,10 @@ declare const bindings: {
       options?: TransitionOpts
     ) => BeaconStateView;
   };
+  metrics: {
+    init: () => void;
+    scrapeMetrics: () => Uint8Array;
+  };
   BeaconStateView: typeof BeaconStateView;
 };
 

--- a/examples/metrics.ts
+++ b/examples/metrics.ts
@@ -1,0 +1,100 @@
+import * as fs from "node:fs";
+import http from "node:http";
+import { config } from "@lodestar/config/default";
+import * as era from "@lodestar/era";
+import bindings from "../bindings/src/index.ts";
+import { getFirstEraFilePath } from "../bindings/test/eraFiles.ts";
+
+const PORT = 8008;
+const PKIX_FILE = "./mainnet.pkix";
+
+const hasPkix = (() => {
+  try {
+    fs.accessSync(PKIX_FILE);
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+if (hasPkix) {
+  console.log("Loading pkix cache from disk...");
+  bindings.pubkeys.load(PKIX_FILE);
+} else {
+  console.log("No pkix cache found, ensuring capacity...");
+  bindings.pool.ensureCapacity(10_000_000);
+  bindings.pubkeys.ensureCapacity(2_000_000);
+}
+
+// --- Init metrics (must be before state creation) ---
+
+bindings.metrics.init();
+console.log("Metrics initialized.");
+
+// --- Load beacon state from era file ---
+
+console.log("Opening era reader...");
+const reader = await era.era.EraReader.open(config, getFirstEraFilePath());
+
+console.log("Reading serialized state...");
+const stateBytes = await reader.readSerializedState();
+
+console.log("Creating BeaconStateView...");
+const state = bindings.BeaconStateView.createFromBytes(stateBytes);
+
+if (!hasPkix) {
+  console.log("Saving pkix cache to disk...");
+  bindings.pubkeys.save(PKIX_FILE);
+}
+
+console.log(`State loaded at slot ${state.slot}, epoch ${state.epoch}`);
+
+var slot = state.slot;
+
+
+console.log(`Processing slots: ${state.slot} -> ${state.slot + 1}...`);
+console.time("processSlots");
+state.processSlots(++slot);
+console.timeEnd("processSlots");
+
+// --- Preview scraped metrics ---
+
+const preview = bindings.metrics.scrapeMetrics();
+console.log("\n--- Metrics preview (first 2000 chars) ---");
+console.log(preview.slice(0, 2000));
+console.log("---\n");
+
+
+console.time("processSlots");
+state.processSlots(++slot);
+console.timeEnd("processSlots");
+
+const preview2 = bindings.metrics.scrapeMetrics();
+console.log("\n--- Metrics preview (first 2000 chars) ---");
+console.log(preview2.slice(0, 2000));
+console.log("---\n");
+
+// --- Start HTTP metrics server ---
+
+const server = http.createServer((_req, res) => {
+  if (_req.url === "/metrics") {
+    const metrics = bindings.metrics.scrapeMetrics();
+    res.writeHead(200, { "Content-Type": "text/plain; version=0.0.4" });
+    res.end(metrics);
+  } else if (_req.url === "/slot") {
+    console.time("processSlots");
+    state.processSlots(++slot);
+    console.timeEnd("processSlots");
+    res.writeHead(200, { "Content-Type": "text/plain; version=0.0.4" });
+    res.end();
+  } else {
+    res.writeHead(404);
+    res.end("Not found. Use /metrics endpoint.\n");
+  }
+});
+
+server.listen(PORT, () => {
+  console.log(`Metrics server listening on http://localhost:${PORT}/metrics`);
+  console.log("You can scrape metrics with: curl http://localhost:8008/metrics");
+  console.log("Or run Prometheus with: docker run -p 9090:9090 -v $(pwd)/examples/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus");
+});

--- a/examples/metrics.ts
+++ b/examples/metrics.ts
@@ -8,6 +8,22 @@
  *
  * On startup it initializes the NAPI bindings, loads (or creates) a PKIX pubkey
  * cache, and deserializes a beacon state from the first available ERA file.
+ *
+ * To check if it works:
+ *
+ * First download era files:
+ *
+ * ```sh
+ * $ zig build run:download_era_files
+ * ```
+ *
+ * Then run the server:
+ *
+ * ```sh
+ * $ node examples/metrics.ts
+ * ```
+ *
+ * Visit the endpoints stated above to interact with the example and check metrics.
  */
 import * as fs from "node:fs";
 import http from "node:http";

--- a/examples/metrics.ts
+++ b/examples/metrics.ts
@@ -1,9 +1,20 @@
+/**
+ * Metrics example server that loads a beacon state from an ERA file and exposes
+ * two HTTP endpoints:
+ *
+ * - `GET /metrics` — scrapes and returns Prometheus-formatted metrics.
+ * - `GET /stf` — advances the beacon state by one slot, applying a block if one
+ *   exists or processing an empty slot otherwise.
+ *
+ * On startup it initializes the NAPI bindings, loads (or creates) a PKIX pubkey
+ * cache, and deserializes a beacon state from the first available ERA file.
+ */
 import * as fs from "node:fs";
 import http from "node:http";
 import { config } from "@lodestar/config/default";
 import * as era from "@lodestar/era";
-import bindings from "../bindings/src/index.ts";
-import { getFirstEraFilePath } from "../bindings/test/eraFiles.ts";
+import bindings from "../bindings/src/index.js";
+import { getFirstEraFilePath, getEraFilePaths } from "../bindings/test/eraFiles.ts";
 
 const PORT = 8008;
 const PKIX_FILE = "./mainnet.pkix";
@@ -21,26 +32,23 @@ if (hasPkix) {
   console.log("Loading pkix cache from disk...");
   bindings.pubkeys.load(PKIX_FILE);
 } else {
-  console.log("No pkix cache found, ensuring capacity...");
+  console.log("No pkix cache found, initializing pool and pkix cache...");
   bindings.pool.ensureCapacity(10_000_000);
   bindings.pubkeys.ensureCapacity(2_000_000);
 }
 
-// --- Init metrics (must be before state creation) ---
-
+console.log("Initializing metrics...");
 bindings.metrics.init();
-console.log("Metrics initialized.");
 
-// --- Load beacon state from era file ---
-
-console.log("Opening era reader...");
+console.log("Opening era readers...");
 const reader = await era.era.EraReader.open(config, getFirstEraFilePath());
+const nextReader = await era.era.EraReader.open(config, getEraFilePaths()[1]);
 
 console.log("Reading serialized state...");
 const stateBytes = await reader.readSerializedState();
 
 console.log("Creating BeaconStateView...");
-const state = bindings.BeaconStateView.createFromBytes(stateBytes);
+var state = bindings.BeaconStateView.createFromBytes(stateBytes);
 
 if (!hasPkix) {
   console.log("Saving pkix cache to disk...");
@@ -49,44 +57,31 @@ if (!hasPkix) {
 
 console.log(`State loaded at slot ${state.slot}, epoch ${state.epoch}`);
 
-var slot = state.slot;
-
-
-console.log(`Processing slots: ${state.slot} -> ${state.slot + 1}...`);
-console.time("processSlots");
-state.processSlots(++slot);
-console.timeEnd("processSlots");
-
-// --- Preview scraped metrics ---
-
-const preview = bindings.metrics.scrapeMetrics();
-console.log("\n--- Metrics preview (first 2000 chars) ---");
-console.log(preview.slice(0, 2000));
-console.log("---\n");
-
-
-console.time("processSlots");
-state.processSlots(++slot);
-console.timeEnd("processSlots");
-
-const preview2 = bindings.metrics.scrapeMetrics();
-console.log("\n--- Metrics preview (first 2000 chars) ---");
-console.log(preview2.slice(0, 2000));
-console.log("---\n");
-
-// --- Start HTTP metrics server ---
-
-const server = http.createServer((_req, res) => {
+const server = http.createServer(async (_req, res) => {
   if (_req.url === "/metrics") {
     const metrics = bindings.metrics.scrapeMetrics();
     res.writeHead(200, { "Content-Type": "text/plain; version=0.0.4" });
     res.end(metrics);
-  } else if (_req.url === "/slot") {
-    console.time("processSlots");
-    state.processSlots(++slot);
-    console.timeEnd("processSlots");
-    res.writeHead(200, { "Content-Type": "text/plain; version=0.0.4" });
-    res.end();
+  } else if (_req.url === "/stf") {
+    try {
+      const nextSlot = state.slot + 1;
+      const signedBlockBytes = await nextReader.readSerializedBlock(nextSlot);
+
+      console.time("stateTransition");
+      if (signedBlockBytes) {
+        state = bindings.stateTransition.stateTransition(state, signedBlockBytes as Uint8Array);
+      } else {
+        state = state.processSlots(nextSlot);
+      }
+      console.timeEnd("stateTransition");
+
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(`State transitioned to slot ${state.slot}, epoch ${state.epoch}\n`);
+    } catch (e) {
+      console.error("stateTransition error:", e);
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end(`Error in state transition: ${e}\n`);
+    }
   } else {
     res.writeHead(404);
     res.end("Not found. Use /metrics endpoint.\n");
@@ -96,5 +91,6 @@ const server = http.createServer((_req, res) => {
 server.listen(PORT, () => {
   console.log(`Metrics server listening on http://localhost:${PORT}/metrics`);
   console.log("You can scrape metrics with: curl http://localhost:8008/metrics");
+  console.log("You can transition state with: curl http://localhost:8008/stf");
   console.log("Or run Prometheus with: docker run -p 9090:9090 -v $(pwd)/examples/prometheus.yml:/etc/prometheus/prometheus.yml prom/prometheus");
 });


### PR DESCRIPTION
Provides an example of how metrics should be scraped via bindings. This will be useful for when we migrate to zig native metrics.

This exists alongside the native zig example, currently existing (but renamed in #239)

Instructions to run the example are found in `examples/metrics.ts` itself. To run:

Download era files:
```sh
zig build run:download_era_files
```

Then run the server, and interact with the endpoints:

```sh
node examples/metrics.ts
```

You can run a prometheus instance or visit the `/metrics` endpoint to see the scraped metrics.