### PR TITLE
test(stf): add unit tests for isValidBlsToExecutionChange

### DIFF
--- a/src/state_transition/block/process_bls_to_execution_change.zig
+++ b/src/state_transition/block/process_bls_to_execution_change.zig
@@ -76,23 +76,19 @@ const TestEnvironment = struct {
     pool: Node.Pool,
     test_state: TestCachedBeaconState,
 
-    const num_validators = 256;
-    const pool_size = num_validators * 5;
+    fn init(self: *TestEnvironment, allocator: std.mem.Allocator, num_validators: u32) !void {
+        const pool_size = num_validators * 5;
 
-    fn init(allocator: std.mem.Allocator) !*TestEnvironment {
-        const self = try allocator.create(TestEnvironment);
-        errdefer allocator.destroy(self);
         self.allocator = allocator;
         self.pool = try Node.Pool.init(allocator, pool_size);
         errdefer self.pool.deinit();
+
         self.test_state = try TestCachedBeaconState.init(allocator, &self.pool, num_validators);
-        return self;
     }
 
     fn deinit(self: *TestEnvironment) void {
         self.test_state.deinit();
         self.pool.deinit();
-        self.allocator.destroy(self);
     }
 };
 
@@ -125,7 +121,8 @@ fn setupValidBlsToExecutionChange(state: anytype) !SignedBLSToExecutionChange {
 }
 
 test "bls to execution change - valid" {
-    const env = try TestEnvironment.init(std.testing.allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(std.testing.allocator, 256);
     defer env.deinit();
 
     const state = env.test_state.cached_state.state.castToFork(.electra);
@@ -136,7 +133,8 @@ test "bls to execution change - valid" {
 }
 
 test "bls to execution change - invalid validator index" {
-    const env = try TestEnvironment.init(std.testing.allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(std.testing.allocator, 256);
     defer env.deinit();
 
     const state = env.test_state.cached_state.state.castToFork(.electra);
@@ -157,7 +155,8 @@ test "bls to execution change - invalid validator index" {
 }
 
 test "bls to execution change - invalid withdrawal credentials prefix" {
-    const env = try TestEnvironment.init(std.testing.allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(std.testing.allocator, 256);
     defer env.deinit();
 
     const state = env.test_state.cached_state.state.castToFork(.electra);
@@ -185,7 +184,8 @@ test "bls to execution change - invalid withdrawal credentials prefix" {
 }
 
 test "bls to execution change - mismatched credentials" {
-    const env = try TestEnvironment.init(std.testing.allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(std.testing.allocator, 256);
     defer env.deinit();
 
     const state = env.test_state.cached_state.state.castToFork(.electra);

--- a/src/state_transition/block/process_bls_to_execution_change.zig
+++ b/src/state_transition/block/process_bls_to_execution_change.zig
@@ -65,3 +65,135 @@ pub fn isValidBlsToExecutionChange(
         }
     }
 }
+
+const TestCachedBeaconState = @import("../test_utils/root.zig").TestCachedBeaconState;
+const interopPubkeysCached = @import("../test_utils/interop_pubkeys.zig").interopPubkeysCached;
+const Node = @import("persistent_merkle_tree").Node;
+const BLSPubkey = types.primitive.BLSPubkey.Type;
+
+/// Helper to set up a valid BLS-to-execution-change scenario for validator 0.
+/// Returns the signed message and sets the validator's withdrawal_credentials to match.
+fn setupValidBlsToExecutionChange(state: anytype) !SignedBLSToExecutionChange {
+    // Get validator 0's interop pubkey
+    var pubkeys: [1]BLSPubkey = undefined;
+    try interopPubkeysCached(1, &pubkeys);
+
+    // Hash the pubkey and set byte 0 to BLS_WITHDRAWAL_PREFIX
+    var expected_credentials: Root = undefined;
+    Sha256.hash(&pubkeys[0], &expected_credentials, .{});
+    expected_credentials[0] = c.BLS_WITHDRAWAL_PREFIX;
+
+    // Set validator 0's withdrawal_credentials to match
+    var validators = try state.validators();
+    var validator = try validators.get(0);
+    try validator.setValue("withdrawal_credentials", &expected_credentials);
+
+    const signed_msg: SignedBLSToExecutionChange = .{
+        .message = .{
+            .validator_index = 0,
+            .from_bls_pubkey = pubkeys[0],
+            .to_execution_address = [_]u8{0xab} ** 20,
+        },
+        .signature = [_]u8{0} ** 96,
+    };
+    return signed_msg;
+}
+
+test "bls to execution change - valid" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 256 * 5);
+    defer pool.deinit();
+
+    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
+    defer test_state.deinit();
+
+    const state = test_state.cached_state.state.castToFork(.electra);
+    const signed_msg = try setupValidBlsToExecutionChange(state);
+
+    // Should succeed with verify_signature=false
+    try isValidBlsToExecutionChange(.electra, test_state.config, state, &signed_msg, false);
+}
+
+test "bls to execution change - invalid validator index" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 256 * 5);
+    defer pool.deinit();
+
+    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
+    defer test_state.deinit();
+
+    const state = test_state.cached_state.state.castToFork(.electra);
+
+    const signed_msg: SignedBLSToExecutionChange = .{
+        .message = .{
+            .validator_index = 9999, // out of bounds
+            .from_bls_pubkey = [_]u8{0} ** 48,
+            .to_execution_address = [_]u8{0} ** 20,
+        },
+        .signature = [_]u8{0} ** 96,
+    };
+
+    try std.testing.expectError(
+        error.InvalidBlsToExecutionChange,
+        isValidBlsToExecutionChange(.electra, test_state.config, state, &signed_msg, false),
+    );
+}
+
+test "bls to execution change - invalid withdrawal credentials prefix" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 256 * 5);
+    defer pool.deinit();
+
+    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
+    defer test_state.deinit();
+
+    const state = test_state.cached_state.state.castToFork(.electra);
+
+    // Set validator 0's withdrawal_credentials prefix to ETH1 (not BLS)
+    var bad_credentials: Root = [_]u8{0} ** 32;
+    bad_credentials[0] = c.ETH1_ADDRESS_WITHDRAWAL_PREFIX;
+    var validators = try state.validators();
+    var validator = try validators.get(0);
+    try validator.setValue("withdrawal_credentials", &bad_credentials);
+
+    const signed_msg: SignedBLSToExecutionChange = .{
+        .message = .{
+            .validator_index = 0,
+            .from_bls_pubkey = [_]u8{0} ** 48,
+            .to_execution_address = [_]u8{0} ** 20,
+        },
+        .signature = [_]u8{0} ** 96,
+    };
+
+    try std.testing.expectError(
+        error.InvalidWithdrawalCredentialsPrefix,
+        isValidBlsToExecutionChange(.electra, test_state.config, state, &signed_msg, false),
+    );
+}
+
+test "bls to execution change - mismatched credentials" {
+    const allocator = std.testing.allocator;
+    var pool = try Node.Pool.init(allocator, 256 * 5);
+    defer pool.deinit();
+
+    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
+    defer test_state.deinit();
+
+    const state = test_state.cached_state.state.castToFork(.electra);
+
+    // Validator 0 has withdrawal_credentials = all zeros (first byte 0x00 = BLS_WITHDRAWAL_PREFIX)
+    // but the hash of from_bls_pubkey won't match the rest of the zeros
+    const signed_msg: SignedBLSToExecutionChange = .{
+        .message = .{
+            .validator_index = 0,
+            .from_bls_pubkey = [_]u8{0xff} ** 48, // hash won't match all-zero credentials
+            .to_execution_address = [_]u8{0} ** 20,
+        },
+        .signature = [_]u8{0} ** 96,
+    };
+
+    try std.testing.expectError(
+        error.InvalidWithdrawalCredentials,
+        isValidBlsToExecutionChange(.electra, test_state.config, state, &signed_msg, false),
+    );
+}

--- a/src/state_transition/block/process_bls_to_execution_change.zig
+++ b/src/state_transition/block/process_bls_to_execution_change.zig
@@ -71,6 +71,31 @@ const interopPubkeysCached = @import("../test_utils/interop_pubkeys.zig").intero
 const Node = @import("persistent_merkle_tree").Node;
 const BLSPubkey = types.primitive.BLSPubkey.Type;
 
+const TestEnvironment = struct {
+    allocator: std.mem.Allocator,
+    pool: Node.Pool,
+    test_state: TestCachedBeaconState,
+
+    const num_validators = 256;
+    const pool_size = num_validators * 5;
+
+    fn init(allocator: std.mem.Allocator) !*TestEnvironment {
+        const self = try allocator.create(TestEnvironment);
+        errdefer allocator.destroy(self);
+        self.allocator = allocator;
+        self.pool = try Node.Pool.init(allocator, pool_size);
+        errdefer self.pool.deinit();
+        self.test_state = try TestCachedBeaconState.init(allocator, &self.pool, num_validators);
+        return self;
+    }
+
+    fn deinit(self: *TestEnvironment) void {
+        self.test_state.deinit();
+        self.pool.deinit();
+        self.allocator.destroy(self);
+    }
+};
+
 /// Helper to set up a valid BLS-to-execution-change scenario for validator 0.
 /// Returns the signed message and sets the validator's withdrawal_credentials to match.
 fn setupValidBlsToExecutionChange(state: anytype) !SignedBLSToExecutionChange {
@@ -100,29 +125,21 @@ fn setupValidBlsToExecutionChange(state: anytype) !SignedBLSToExecutionChange {
 }
 
 test "bls to execution change - valid" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(allocator, 256 * 5);
-    defer pool.deinit();
+    const env = try TestEnvironment.init(std.testing.allocator);
+    defer env.deinit();
 
-    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
-    defer test_state.deinit();
-
-    const state = test_state.cached_state.state.castToFork(.electra);
+    const state = env.test_state.cached_state.state.castToFork(.electra);
     const signed_msg = try setupValidBlsToExecutionChange(state);
 
     // Should succeed with verify_signature=false
-    try isValidBlsToExecutionChange(.electra, test_state.config, state, &signed_msg, false);
+    try isValidBlsToExecutionChange(.electra, env.test_state.config, state, &signed_msg, false);
 }
 
 test "bls to execution change - invalid validator index" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(allocator, 256 * 5);
-    defer pool.deinit();
+    const env = try TestEnvironment.init(std.testing.allocator);
+    defer env.deinit();
 
-    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
-    defer test_state.deinit();
-
-    const state = test_state.cached_state.state.castToFork(.electra);
+    const state = env.test_state.cached_state.state.castToFork(.electra);
 
     const signed_msg: SignedBLSToExecutionChange = .{
         .message = .{
@@ -135,19 +152,15 @@ test "bls to execution change - invalid validator index" {
 
     try std.testing.expectError(
         error.InvalidBlsToExecutionChange,
-        isValidBlsToExecutionChange(.electra, test_state.config, state, &signed_msg, false),
+        isValidBlsToExecutionChange(.electra, env.test_state.config, state, &signed_msg, false),
     );
 }
 
 test "bls to execution change - invalid withdrawal credentials prefix" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(allocator, 256 * 5);
-    defer pool.deinit();
+    const env = try TestEnvironment.init(std.testing.allocator);
+    defer env.deinit();
 
-    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
-    defer test_state.deinit();
-
-    const state = test_state.cached_state.state.castToFork(.electra);
+    const state = env.test_state.cached_state.state.castToFork(.electra);
 
     // Set validator 0's withdrawal_credentials prefix to ETH1 (not BLS)
     var bad_credentials: Root = [_]u8{0} ** 32;
@@ -167,19 +180,15 @@ test "bls to execution change - invalid withdrawal credentials prefix" {
 
     try std.testing.expectError(
         error.InvalidWithdrawalCredentialsPrefix,
-        isValidBlsToExecutionChange(.electra, test_state.config, state, &signed_msg, false),
+        isValidBlsToExecutionChange(.electra, env.test_state.config, state, &signed_msg, false),
     );
 }
 
 test "bls to execution change - mismatched credentials" {
-    const allocator = std.testing.allocator;
-    var pool = try Node.Pool.init(allocator, 256 * 5);
-    defer pool.deinit();
+    const env = try TestEnvironment.init(std.testing.allocator);
+    defer env.deinit();
 
-    var test_state = try TestCachedBeaconState.init(allocator, &pool, 256);
-    defer test_state.deinit();
-
-    const state = test_state.cached_state.state.castToFork(.electra);
+    const state = env.test_state.cached_state.state.castToFork(.electra);
 
     // Validator 0 has withdrawal_credentials = all zeros (first byte 0x00 = BLS_WITHDRAWAL_PREFIX)
     // but the hash of from_bls_pubkey won't match the rest of the zeros
@@ -194,6 +203,6 @@ test "bls to execution change - mismatched credentials" {
 
     try std.testing.expectError(
         error.InvalidWithdrawalCredentials,
-        isValidBlsToExecutionChange(.electra, test_state.config, state, &signed_msg, false),
+        isValidBlsToExecutionChange(.electra, env.test_state.config, state, &signed_msg, false),
     );
 }


### PR DESCRIPTION
Add 4 unit tests for `isValidBlsToExecutionChange` covering all validation paths:

1. **Valid BLS to execution change** — matching withdrawal credentials (SHA256 of interop pubkey with BLS prefix)
2. **Invalid validator index** — out-of-bounds index returns `InvalidBlsToExecutionChange`
3. **Invalid withdrawal credentials prefix** — ETH1 prefix (0x01) instead of BLS (0x00) returns `InvalidWithdrawalCredentialsPrefix`
4. **Mismatched credentials** — BLS prefix correct but pubkey hash doesn't match returns `InvalidWithdrawalCredentials`

All tests use `verify_signature=false` to skip BLS verification.

🤖 Generated with AI assistance