### PR TITLE
test(stf): add unit tests for processAttesterSlashing

### DIFF
--- a/src/state_transition/block/process_attester_slashing.zig
+++ b/src/state_transition/block/process_attester_slashing.zig
@@ -122,12 +122,9 @@ const TestEnvironment = struct {
     test_state: TestCachedBeaconState,
     slashings_cache: SlashingsCache,
 
-    const num_validators = 256;
-    const pool_size = num_validators * 5;
+    fn init(self: *TestEnvironment, allocator: Allocator, num_validators: u32) !void {
+        const pool_size = num_validators * 5;
 
-    fn init(allocator: Allocator) !*TestEnvironment {
-        const self = try allocator.create(TestEnvironment);
-        errdefer allocator.destroy(self);
         self.allocator = allocator;
         self.pool = try Node.Pool.init(allocator, pool_size);
         errdefer self.pool.deinit();
@@ -140,14 +137,12 @@ const TestEnvironment = struct {
             const slot = try lbh.get("slot");
             self.slashings_cache.updateLatestBlockSlot(slot);
         }
-        return self;
     }
 
     fn deinit(self: *TestEnvironment) void {
         self.slashings_cache.deinit();
         self.test_state.deinit();
         self.pool.deinit();
-        self.allocator.destroy(self);
     }
 };
 
@@ -200,7 +195,8 @@ fn freeSlashing(allocator: Allocator, slashing: *types.phase0.AttesterSlashing.T
 
 test "assertValidAttesterSlashing - double vote sanity" {
     const allocator = testing.allocator;
-    const env = try TestEnvironment.init(allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(allocator, 256);
     defer env.deinit();
 
     const indices = &[_]ValidatorIndex{ 1, 2, 3 };
@@ -221,7 +217,8 @@ test "assertValidAttesterSlashing - double vote sanity" {
 
 test "assertValidAttesterSlashing - not slashable (same data)" {
     const allocator = testing.allocator;
-    const env = try TestEnvironment.init(allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(allocator, 256);
     defer env.deinit();
 
     const indices = &[_]ValidatorIndex{ 1, 2, 3 };
@@ -247,7 +244,8 @@ test "assertValidAttesterSlashing - not slashable (same data)" {
 
 test "assertValidAttesterSlashing - empty attesting indices" {
     const allocator = testing.allocator;
-    const env = try TestEnvironment.init(allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(allocator, 256);
     defer env.deinit();
 
     var slashing = try makeDoubleVoteSlashing(allocator, &[_]ValidatorIndex{});
@@ -270,7 +268,8 @@ test "assertValidAttesterSlashing - empty attesting indices" {
 
 test "assertValidAttesterSlashing - unsorted indices" {
     const allocator = testing.allocator;
-    const env = try TestEnvironment.init(allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(allocator, 256);
     defer env.deinit();
 
     // Indices must be sorted ascending
@@ -294,7 +293,8 @@ test "assertValidAttesterSlashing - unsorted indices" {
 
 test "processAttesterSlashing - slashes intersecting validators" {
     const allocator = testing.allocator;
-    const env = try TestEnvironment.init(allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(allocator, 256);
     defer env.deinit();
 
     const state = env.test_state.cached_state.state.castToFork(.electra);
@@ -336,7 +336,8 @@ test "processAttesterSlashing - slashes intersecting validators" {
 
 test "processAttesterSlashing - already slashed validator returns error" {
     const allocator = testing.allocator;
-    const env = try TestEnvironment.init(allocator);
+    var env: TestEnvironment = undefined;
+    try env.init(allocator, 256);
     defer env.deinit();
 
     const state = env.test_state.cached_state.state.castToFork(.electra);

--- a/src/state_transition/block/process_attester_slashing.zig
+++ b/src/state_transition/block/process_attester_slashing.zig
@@ -107,3 +107,280 @@ pub fn assertValidAttesterSlashing(
         return error.InvalidAttesterSlashingAttestationInvalid;
     }
 }
+
+const testing = std.testing;
+const TestCachedBeaconState = @import("../test_utils/root.zig").TestCachedBeaconState;
+const Node = @import("persistent_merkle_tree").Node;
+const preset = @import("preset").preset;
+const AttestationData = types.phase0.AttestationData.Type;
+const Checkpoint = types.phase0.Checkpoint.Type;
+const ValidatorIndex = types.primitive.ValidatorIndex.Type;
+
+const TestEnvironment = struct {
+    allocator: Allocator,
+    pool: Node.Pool,
+    test_state: TestCachedBeaconState,
+    slashings_cache: SlashingsCache,
+
+    const num_validators = 256;
+    const pool_size = num_validators * 5;
+
+    fn init(allocator: Allocator) !*TestEnvironment {
+        const self = try allocator.create(TestEnvironment);
+        errdefer allocator.destroy(self);
+        self.allocator = allocator;
+        self.pool = try Node.Pool.init(allocator, pool_size);
+        errdefer self.pool.deinit();
+        self.test_state = try TestCachedBeaconState.init(allocator, &self.pool, num_validators);
+        errdefer self.test_state.deinit();
+        self.slashings_cache = try SlashingsCache.initEmpty(allocator);
+        errdefer self.slashings_cache.deinit();
+        {
+            var lbh = try self.test_state.cached_state.state.castToFork(.electra).latestBlockHeader();
+            const slot = try lbh.get("slot");
+            self.slashings_cache.updateLatestBlockSlot(slot);
+        }
+        return self;
+    }
+
+    fn deinit(self: *TestEnvironment) void {
+        self.slashings_cache.deinit();
+        self.test_state.deinit();
+        self.pool.deinit();
+        self.allocator.destroy(self);
+    }
+};
+
+/// Helper to construct a double-vote attester slashing.
+/// attestation_1 and attestation_2 have the same target epoch but different roots.
+fn makeDoubleVoteSlashing(
+    allocator: Allocator,
+    indices: []const ValidatorIndex,
+) !types.phase0.AttesterSlashing.Type {
+    var idx_list_1 = try std.ArrayListUnmanaged(ValidatorIndex).initCapacity(allocator, indices.len);
+    var idx_list_2 = try std.ArrayListUnmanaged(ValidatorIndex).initCapacity(allocator, indices.len);
+    for (indices) |idx| {
+        idx_list_1.appendAssumeCapacity(idx);
+        idx_list_2.appendAssumeCapacity(idx);
+    }
+
+    const data_1 = AttestationData{
+        .slot = 10,
+        .index = 0,
+        .beacon_block_root = [_]u8{0xaa} ** 32,
+        .source = Checkpoint{ .epoch = 1, .root = [_]u8{0} ** 32 },
+        .target = Checkpoint{ .epoch = 5, .root = [_]u8{0x11} ** 32 },
+    };
+    const data_2 = AttestationData{
+        .slot = 10,
+        .index = 0,
+        .beacon_block_root = [_]u8{0xbb} ** 32,
+        .source = Checkpoint{ .epoch = 1, .root = [_]u8{0} ** 32 },
+        .target = Checkpoint{ .epoch = 5, .root = [_]u8{0x22} ** 32 },
+    };
+
+    return .{
+        .attestation_1 = .{
+            .attesting_indices = idx_list_1,
+            .data = data_1,
+            .signature = [_]u8{0} ** 96,
+        },
+        .attestation_2 = .{
+            .attesting_indices = idx_list_2,
+            .data = data_2,
+            .signature = [_]u8{0} ** 96,
+        },
+    };
+}
+
+fn freeSlashing(allocator: Allocator, slashing: *types.phase0.AttesterSlashing.Type) void {
+    slashing.attestation_1.attesting_indices.deinit(allocator);
+    slashing.attestation_2.attesting_indices.deinit(allocator);
+}
+
+test "assertValidAttesterSlashing - double vote sanity" {
+    const allocator = testing.allocator;
+    const env = try TestEnvironment.init(allocator);
+    defer env.deinit();
+
+    const indices = &[_]ValidatorIndex{ 1, 2, 3 };
+    var slashing = try makeDoubleVoteSlashing(allocator, indices);
+    defer freeSlashing(allocator, &slashing);
+
+    // Should succeed with signature verification disabled
+    try assertValidAttesterSlashing(
+        .electra,
+        allocator,
+        env.test_state.cached_state.config,
+        env.test_state.cached_state.epoch_cache,
+        try env.test_state.cached_state.state.castToFork(.electra).validatorsCount(),
+        &slashing,
+        false, // skip signature verification
+    );
+}
+
+test "assertValidAttesterSlashing - not slashable (same data)" {
+    const allocator = testing.allocator;
+    const env = try TestEnvironment.init(allocator);
+    defer env.deinit();
+
+    const indices = &[_]ValidatorIndex{ 1, 2, 3 };
+    var slashing = try makeDoubleVoteSlashing(allocator, indices);
+    defer freeSlashing(allocator, &slashing);
+
+    // Make both attestations have identical data — not slashable
+    slashing.attestation_2.data = slashing.attestation_1.data;
+
+    try testing.expectError(
+        error.InvalidAttesterSlashingNotSlashable,
+        assertValidAttesterSlashing(
+            .electra,
+            allocator,
+            env.test_state.cached_state.config,
+            env.test_state.cached_state.epoch_cache,
+            try env.test_state.cached_state.state.castToFork(.electra).validatorsCount(),
+            &slashing,
+            false,
+        ),
+    );
+}
+
+test "assertValidAttesterSlashing - empty attesting indices" {
+    const allocator = testing.allocator;
+    const env = try TestEnvironment.init(allocator);
+    defer env.deinit();
+
+    var slashing = try makeDoubleVoteSlashing(allocator, &[_]ValidatorIndex{});
+    defer freeSlashing(allocator, &slashing);
+
+    // Empty indices should fail validation (isValidIndexedAttestation requires non-empty)
+    try testing.expectError(
+        error.InvalidAttesterSlashingAttestationInvalid,
+        assertValidAttesterSlashing(
+            .electra,
+            allocator,
+            env.test_state.cached_state.config,
+            env.test_state.cached_state.epoch_cache,
+            try env.test_state.cached_state.state.castToFork(.electra).validatorsCount(),
+            &slashing,
+            false,
+        ),
+    );
+}
+
+test "assertValidAttesterSlashing - unsorted indices" {
+    const allocator = testing.allocator;
+    const env = try TestEnvironment.init(allocator);
+    defer env.deinit();
+
+    // Indices must be sorted ascending
+    const unsorted_indices = &[_]ValidatorIndex{ 3, 1, 2 };
+    var slashing = try makeDoubleVoteSlashing(allocator, unsorted_indices);
+    defer freeSlashing(allocator, &slashing);
+
+    try testing.expectError(
+        error.InvalidAttesterSlashingAttestationInvalid,
+        assertValidAttesterSlashing(
+            .electra,
+            allocator,
+            env.test_state.cached_state.config,
+            env.test_state.cached_state.epoch_cache,
+            try env.test_state.cached_state.state.castToFork(.electra).validatorsCount(),
+            &slashing,
+            false,
+        ),
+    );
+}
+
+test "processAttesterSlashing - slashes intersecting validators" {
+    const allocator = testing.allocator;
+    const env = try TestEnvironment.init(allocator);
+    defer env.deinit();
+
+    const state = env.test_state.cached_state.state.castToFork(.electra);
+    const epoch_cache = env.test_state.cached_state.epoch_cache;
+    const current_epoch = epoch_cache.epoch;
+
+    // Pick a validator that's active and not already slashed
+    const target_index: ValidatorIndex = 42;
+    const indices = &[_]ValidatorIndex{target_index};
+    var slashing = try makeDoubleVoteSlashing(allocator, indices);
+    defer freeSlashing(allocator, &slashing);
+
+    // Read balance before slashing
+    var balances = try state.balances();
+    const balance_before = try balances.get(target_index);
+
+    try processAttesterSlashing(
+        .electra,
+        allocator,
+        env.test_state.cached_state.config,
+        epoch_cache,
+        state,
+        &env.slashings_cache,
+        current_epoch,
+        &slashing,
+        false,
+    );
+
+    // Verify the validator was actually slashed
+    var validators = try state.validators();
+    var validator: types.phase0.Validator.Type = undefined;
+    try validators.getValue(undefined, target_index, &validator);
+    try testing.expect(validator.slashed);
+
+    // Balance should have decreased (slashing penalty)
+    const balance_after = try balances.get(target_index);
+    try testing.expect(balance_after < balance_before);
+}
+
+test "processAttesterSlashing - already slashed validator returns error" {
+    const allocator = testing.allocator;
+    const env = try TestEnvironment.init(allocator);
+    defer env.deinit();
+
+    const state = env.test_state.cached_state.state.castToFork(.electra);
+    const epoch_cache = env.test_state.cached_state.epoch_cache;
+    const current_epoch = epoch_cache.epoch;
+
+    const target_index: ValidatorIndex = 42;
+    const indices = &[_]ValidatorIndex{target_index};
+
+    // First slashing should succeed
+    var slashing1 = try makeDoubleVoteSlashing(allocator, indices);
+    defer freeSlashing(allocator, &slashing1);
+
+    try processAttesterSlashing(
+        .electra,
+        allocator,
+        env.test_state.cached_state.config,
+        epoch_cache,
+        state,
+        &env.slashings_cache,
+        current_epoch,
+        &slashing1,
+        false,
+    );
+
+    // Second slashing of same validator — should fail (already slashed, not slashable)
+    var slashing2 = try makeDoubleVoteSlashing(allocator, indices);
+    defer freeSlashing(allocator, &slashing2);
+    // Use different block roots to avoid being identical
+    slashing2.attestation_1.data.beacon_block_root = [_]u8{0xcc} ** 32;
+    slashing2.attestation_2.data.beacon_block_root = [_]u8{0xdd} ** 32;
+
+    try testing.expectError(
+        error.InvalidAttesterSlashingNoSlashableValidators,
+        processAttesterSlashing(
+            .electra,
+            allocator,
+            env.test_state.cached_state.config,
+            epoch_cache,
+            state,
+            &env.slashings_cache,
+            current_epoch,
+            &slashing2,
+            false,
+        ),
+    );
+}


### PR DESCRIPTION
## Summary

Add 6 unit tests for `processAttesterSlashing` and `assertValidAttesterSlashing` in `src/state_transition/block/process_attester_slashing.zig`.

### Tests added

**`assertValidAttesterSlashing`:**
- Double vote sanity — valid slashable attestation data passes validation
- Not slashable (same data) — identical attestation data returns `InvalidAttesterSlashingNotSlashable`
- Empty attesting indices — returns `InvalidAttesterSlashingAttestationInvalid`
- Unsorted indices — returns `InvalidAttesterSlashingAttestationInvalid`

**`processAttesterSlashing`:**
- Slashes intersecting validators — verifies `slashed` flag set and balance decreased
- Already-slashed validator — returns `InvalidAttesterSlashingNoSlashableValidators`

### Notes
- Uses `TestEnvironment` struct pattern (consistent with #271, #272, #274)
- All tests skip BLS signature verification to focus on logic paths
- Spec tests already cover full signature verification paths

🤖 Generated with AI assistance