### PR TITLE
fix: use atomic operations for ReferenceCount thread safety

### DIFF
--- a/src/state_transition/utils/reference_count.zig
+++ b/src/state_transition/utils/reference_count.zig
@@ -5,9 +5,8 @@ const Allocator = std.mem.Allocator;
 /// T should be `*Something`, not `*const Something` due to deinit()
 pub fn ReferenceCount(comptime T: type) type {
     return struct {
-        // TODO: switch to std.atomic
         allocator: Allocator,
-        _ref_count: usize,
+        _ref_count: std.atomic.Value(usize),
         instance: T,
 
         pub fn init(allocator: Allocator, instance: T) !*@This() {
@@ -15,7 +14,7 @@ pub fn ReferenceCount(comptime T: type) type {
             errdefer allocator.destroy(ptr);
             ptr.* = .{
                 .allocator = allocator,
-                ._ref_count = 1,
+                ._ref_count = std.atomic.Value(usize).init(1),
                 .instance = instance,
             };
             return ptr;
@@ -36,13 +35,13 @@ pub fn ReferenceCount(comptime T: type) type {
         }
 
         pub fn acquire(self: *@This()) *@This() {
-            self._ref_count += 1;
+            _ = self._ref_count.fetchAdd(1, .acq_rel);
             return self;
         }
 
         pub fn release(self: *@This()) void {
-            self._ref_count -= 1;
-            if (self._ref_count == 0) {
+            const prev = self._ref_count.fetchSub(1, .acq_rel);
+            if (prev == 1) {
                 self.deinit();
             }
         }


### PR DESCRIPTION
## Summary

Replace plain `usize` with `std.atomic.Value(usize)` for the reference count field in `ReferenceCount`. `acquire()` and `release()` now use `fetchAdd`/`fetchSub` with `acq_rel` ordering.

## Motivation

`ReferenceCount` wraps `EffectiveBalanceIncrements`, `SyncCommitteeCache`, and `EpochShuffling` — all shared across the state transition pipeline. Without atomic operations, concurrent `acquire()`/`release()` calls are data races. This resolves the existing TODO comment.

## Changes

- `_ref_count: usize` → `_ref_count: std.atomic.Value(usize)`
- `acquire()`: uses `fetchAdd(1, .acq_rel)`
- `release()`: uses `fetchSub(1, .acq_rel)`, checks previous value == 1 for cleanup (avoids reading stale count after decrement)

Existing tests pass (`zig build test:state_transition`).

🤖 Generated with AI assistance