### PR TITLE
chore: bump spec test version to v1.6.1

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -25,7 +25,7 @@ pub fn build(b: *std.Build) void {
     const options_spec_test_options = b.addOptions();
     const option_spec_test_url = b.option([]const u8, "spec_test_url", "") orelse "https://github.com/ethereum/consensus-specs";
     options_spec_test_options.addOption([]const u8, "spec_test_url", option_spec_test_url);
-    const option_spec_test_version = b.option([]const u8, "spec_test_version", "") orelse "v1.6.0-beta.2";
+    const option_spec_test_version = b.option([]const u8, "spec_test_version", "") orelse "v1.6.1";
     options_spec_test_options.addOption([]const u8, "spec_test_version", option_spec_test_version);
     const option_spec_test_out_dir = b.option([]const u8, "spec_test_out_dir", "") orelse "test/spec/spec_tests";
     options_spec_test_options.addOption([]const u8, "spec_test_out_dir", option_spec_test_out_dir);

--- a/zbuild.zon
+++ b/zbuild.zon
@@ -67,7 +67,7 @@
                 .type = "string",
             },
             .spec_test_version = .{
-                .default = "v1.6.0-beta.2",
+                .default = "v1.6.1",
                 .type = "string",
             },
             .spec_test_out_dir = .{


### PR DESCRIPTION
## Summary

Bump spec test version from `v1.6.0-beta.2` to `v1.6.1`.

## Changes between versions (19 commits)

| PR | Description | Impact on us |
|---|---|---|
| #4689 | Set fork epoch & blob schedule for Fulu | Test vector metadata only |
| #4742 | Gossip attestation committee_bits fix | Networking, not STF |
| #4725 | SSZ Union integer encoding fix | We don't use SSZ unions |
| #4719-#4741 | Gloas spec cleanups (parts 4-6) | Gloas only, not implemented |
| #4715 | Version bump to v1.6.0 | Version string |
| #4743 | Version bump to v1.6.1 | Version string |

No state_transition or SSZ test vector changes expected. CI will confirm.

## Next step

After this lands, consider bumping to `v1.7.0-alpha.4` which includes Fulu cell dissemination test vectors (matches our PR #284).

🤖 Generated with AI assistance