### PR TITLE
fix: use body hash in blockToHeader + resolve stale TODOs

### DIFF
--- a/src/state_transition/block/process_block_header.zig
+++ b/src/state_transition/block/process_block_header.zig
@@ -75,7 +75,8 @@ pub fn blockToHeader(allocator: Allocator, signed_block: AnySignedBeaconBlock, o
     out.proposer_index = block.proposerIndex();
     out.parent_root = block.parentRoot().*;
     out.state_root = block.stateRoot().*;
-    try block.hashTreeRoot(allocator, &out.body_root);
+    const body = block.beaconBlockBody();
+    try body.hashTreeRoot(allocator, &out.body_root);
 }
 
 const TestCachedBeaconState = @import("../test_utils/root.zig").TestCachedBeaconState;

--- a/src/state_transition/utils/attester_status.zig
+++ b/src/state_transition/utils/attester_status.zig
@@ -29,4 +29,6 @@ pub fn hasMarkers(flags: u8, markers: u8) bool {
     return (flags & markers) == markers;
 }
 
-// TODOs: implement missing functions
+// Note: TS lodestar also has parseAttesterFlags, toAttesterFlags, parseParticipationFlags
+// These are used for validator monitoring and debug tooling, not STF correctness.
+// Add them when implementing the validator monitor (beacon-node layer).

--- a/src/state_transition/utils/block_root.zig
+++ b/src/state_transition/utils/block_root.zig
@@ -27,6 +27,6 @@ pub fn getBlockRoot(comptime fork: ForkSeq, state: *BeaconState(fork), epoch: Ep
     return getBlockRootAtSlot(fork, state, computeStartSlotAtEpoch(epoch));
 }
 
-// TODO: getTemporaryBlockHeader
+// Note: getTemporaryBlockHeader is implemented via blockToHeader in process_block_header.zig
 
-// TODO: signedBlockToSignedHeader
+// Note: signedBlockToSignedHeader — implement when needed for beacon-node layer


### PR DESCRIPTION
## Summary

**Bug fix**: `blockToHeader` was computing `body_root` as `hash_tree_root(block)` instead of `hash_tree_root(block.body)`. This would produce incorrect `BeaconBlockHeader` values. The function is currently unused but will be needed for fork choice and beacon-node integration.

**TODO cleanup**: Resolves 3 stale TODOs with actionable notes:
- `attester_status.zig`: Missing functions (`parseAttesterFlags`, etc.) are for validator monitor, not STF — noted for beacon-node layer
- `block_root.zig`: `getTemporaryBlockHeader` already implemented as `blockToHeader` in `process_block_header.zig`; `signedBlockToSignedHeader` deferred to beacon-node layer

🤖 Generated with AI assistance