### PR TITLE
ci: run ssz_static minimal spec tests and general mainnet spec tests on `ReleaseSafe`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Run minimal ssz_static spec tests
         run: |
-          zig build test:ssz_static_spec_tests -Dpreset=minimal
+          zig build test:ssz_static_spec_tests -Dpreset=minimal -Doptimize=ReleaseSafe
 
       - name: Run mainnet ssz_static spec tests
         run: |
@@ -266,7 +266,7 @@ jobs:
           zig build run:write_spec_tests
       - name: Run spec tests - mainnet
         run: |
-          zig build test:spec_tests -Dpreset=mainnet
+          zig build test:spec_tests -Dpreset=mainnet -Doptimize=ReleaseSafe
 
   build-fuzz:
     name: build fuzz harnesses


### PR DESCRIPTION
we were kinda gimping our ci times by not running these heavy tests on `ReleaseSafe`. with `time`:

```
zig build test:spec_tests -Dpreset=mainnet  550.51s user 166.74s system 97% cpu 12:13.24 total
zig build test:spec_tests -Dpreset=mainnet -Doptimize=ReleaseSafe  249.21s user 144.10s system 98% cpu 6:38.58 total

zig build test:ssz_static_spec_tests -Dpreset=minimal  191.13s user 84.31s system 97% cpu 4:42.40 total
zig build test:ssz_static_spec_tests -Dpreset=minimal -Doptimize=ReleaseSafe  165.37s user 93.50s system 97% cpu 4:25.62 total
```

there's more savings to be had but this is a quick one to fix for the slowest tests i identified in past runs