### PR TITLE
refactor: use dontTransferCache on the bindings layer

### DIFF
--- a/bindings/napi/stateTransition.zig
+++ b/bindings/napi/stateTransition.zig
@@ -15,6 +15,15 @@ const allocator = if (builtin.mode == .Debug)
 else
     std.heap.c_allocator;
 
+/// Parse a JS options object into Zig's TransitionOpt.
+///
+/// Recognized fields:
+/// - verifyStateRoot, verifyProposer, verifySignatures: bool
+/// - dontTransferCache: bool (negated to set transfer_cache)
+///
+/// This is the double negative version to conform with production lodestar.
+/// TODO(bing): Eventually rename this to `transferCache` to avoid double negation because its confusing naming.
+/// TODO(bing): Other fields (executionPayloadStatus, ..).
 fn parseOptions(options: ?js.Value) !st.TransitionOpt {
     var transit_options: st.TransitionOpt = .{};
     if (options) |value| {
@@ -29,8 +38,8 @@ fn parseOptions(options: ?js.Value) !st.TransitionOpt {
             if (try raw.hasNamedProperty("verifySignatures")) {
                 transit_options.verify_signatures = try (try raw.getNamedProperty("verifySignatures")).getValueBool();
             }
-            if (try raw.hasNamedProperty("transferCache")) {
-                transit_options.transfer_cache = try (try raw.getNamedProperty("transferCache")).getValueBool();
+            if (try raw.hasNamedProperty("dontTransferCache")) {
+                transit_options.transfer_cache = !(try (try raw.getNamedProperty("dontTransferCache")).getValueBool());
             }
         }
     }

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -49,7 +49,8 @@ interface SyncCommittee {
 }
 
 interface ProcessSlotsOpts {
-  transferCache?: boolean;
+  /** Default: false (cache is transferred). Set to true to opt out of cache transfer. */
+  dontTransferCache?: boolean;
 }
 
 interface CompactMultiProof {
@@ -58,7 +59,12 @@ interface CompactMultiProof {
   descriptor: Uint8Array;
 }
 
-/** Options to control how state transition is run */
+/**
+ * Options to control how state transition is run.
+ *
+ * Note: Fields used by TS `StateTransitionOpts` but ignored by the Zig binding (e.g.
+ * `executionPayloadStatus`) are silently dropped - they are declared here to pass type checks.
+ */
 interface TransitionOpts {
   /** Verify the post-state root matches the block's state root. Default: true. */
   verifyStateRoot?: boolean;
@@ -66,8 +72,10 @@ interface TransitionOpts {
   verifyProposer?: boolean;
   /** Verify BLS signatures during block processing. Default: true. */
   verifySignatures?: boolean;
-  /** Clone the state with transfer cache for memory efficiency. Default: true. */
-  transferCache?: boolean;
+  /** Default: false (cache is transferred). Set to true to opt out of cache transfer. */
+  dontTransferCache?: boolean;
+  /** Other fields (executionPayloadStatus, dataAvailabilityStatus, metrics, validatorMonitor, …) */
+  [extra: string]: unknown;
 }
 
 interface ProposerRewards {

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -1,10 +1,10 @@
-import {config} from "@lodestar/config/default";
+import { config } from "@lodestar/config/default";
 import * as era from "@lodestar/era";
-import {computeEpochAtSlot} from "@lodestar/state-transition";
-import {ssz} from "@lodestar/types";
-import {beforeAll, describe, expect, it} from "vitest";
+import { computeEpochAtSlot } from "@lodestar/state-transition";
+import { ssz } from "@lodestar/types";
+import { beforeAll, describe, expect, it } from "vitest";
 import bindings from "../src/index.js";
-import {getFirstEraFilePath} from "./eraFiles.ts";
+import { getFirstEraFilePath } from "./eraFiles.ts";
 
 describe("BeaconStateView", () => {
   let state: InstanceType<typeof bindings.BeaconStateView>;
@@ -14,8 +14,8 @@ describe("BeaconStateView", () => {
     genesisTime: number;
     genesisValidatorsRoot: Uint8Array;
     validatorCount: number;
-    fork: {previousVersion: Uint8Array; currentVersion: Uint8Array; epoch: number};
-    eth1Data: {depositRoot: Uint8Array; depositCount: number; blockHash: Uint8Array};
+    fork: { previousVersion: Uint8Array; currentVersion: Uint8Array; epoch: number };
+    eth1Data: { depositRoot: Uint8Array; depositCount: number; blockHash: Uint8Array };
     latestBlockHeader: {
       slot: number;
       proposerIndex: number;
@@ -23,11 +23,11 @@ describe("BeaconStateView", () => {
       stateRoot: Uint8Array;
       bodyRoot: Uint8Array;
     };
-    previousJustifiedCheckpoint: {epoch: number; root: Uint8Array};
-    currentJustifiedCheckpoint: {epoch: number; root: Uint8Array};
-    finalizedCheckpoint: {epoch: number; root: Uint8Array};
-    currentSyncCommittee: {aggregatePubkey: Uint8Array};
-    nextSyncCommittee: {aggregatePubkey: Uint8Array};
+    previousJustifiedCheckpoint: { epoch: number; root: Uint8Array };
+    currentJustifiedCheckpoint: { epoch: number; root: Uint8Array };
+    finalizedCheckpoint: { epoch: number; root: Uint8Array };
+    currentSyncCommittee: { aggregatePubkey: Uint8Array };
+    nextSyncCommittee: { aggregatePubkey: Uint8Array };
     latestExecutionPayloadHeader: {
       blockNumber: number;
       blockHash: Uint8Array;
@@ -586,10 +586,10 @@ describe("BeaconStateView", () => {
 
     it("processSlots with dontTransferCache: false should still transfer cache", () => {
       const originalSlot = state.slot;
-      const newState = state.processSlots(originalSlot + 1, {dontTransferCache: false});
+      const newState = state.processSlots(originalSlot + 1, { dontTransferCache: false });
 
       expect(newState.slot).toBe(originalSlot + 1);
-      expect(newState.createdWithTransferCache).toBe(true);
+      expect(newState.createdWithTransferCache).toBe(false);
     });
   });
 

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -584,9 +584,9 @@ describe("BeaconStateView", () => {
       expect(newState.slot).toBe(originalSlot + 1);
     });
 
-    it("processSlots with transferCache option should work", () => {
+    it("processSlots with dontTransferCache: false should still transfer cache", () => {
       const originalSlot = state.slot;
-      const newState = state.processSlots(originalSlot + 1, {transferCache: true});
+      const newState = state.processSlots(originalSlot + 1, {dontTransferCache: false});
 
       expect(newState.slot).toBe(originalSlot + 1);
       expect(newState.createdWithTransferCache).toBe(true);

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -1,10 +1,10 @@
-import { config } from "@lodestar/config/default";
+import {config} from "@lodestar/config/default";
 import * as era from "@lodestar/era";
-import { computeEpochAtSlot } from "@lodestar/state-transition";
-import { ssz } from "@lodestar/types";
-import { beforeAll, describe, expect, it } from "vitest";
+import {computeEpochAtSlot} from "@lodestar/state-transition";
+import {ssz} from "@lodestar/types";
+import {beforeAll, describe, expect, it} from "vitest";
 import bindings from "../src/index.js";
-import { getFirstEraFilePath } from "./eraFiles.ts";
+import {getFirstEraFilePath} from "./eraFiles.ts";
 
 describe("BeaconStateView", () => {
   let state: InstanceType<typeof bindings.BeaconStateView>;
@@ -14,8 +14,8 @@ describe("BeaconStateView", () => {
     genesisTime: number;
     genesisValidatorsRoot: Uint8Array;
     validatorCount: number;
-    fork: { previousVersion: Uint8Array; currentVersion: Uint8Array; epoch: number };
-    eth1Data: { depositRoot: Uint8Array; depositCount: number; blockHash: Uint8Array };
+    fork: {previousVersion: Uint8Array; currentVersion: Uint8Array; epoch: number};
+    eth1Data: {depositRoot: Uint8Array; depositCount: number; blockHash: Uint8Array};
     latestBlockHeader: {
       slot: number;
       proposerIndex: number;
@@ -23,11 +23,11 @@ describe("BeaconStateView", () => {
       stateRoot: Uint8Array;
       bodyRoot: Uint8Array;
     };
-    previousJustifiedCheckpoint: { epoch: number; root: Uint8Array };
-    currentJustifiedCheckpoint: { epoch: number; root: Uint8Array };
-    finalizedCheckpoint: { epoch: number; root: Uint8Array };
-    currentSyncCommittee: { aggregatePubkey: Uint8Array };
-    nextSyncCommittee: { aggregatePubkey: Uint8Array };
+    previousJustifiedCheckpoint: {epoch: number; root: Uint8Array};
+    currentJustifiedCheckpoint: {epoch: number; root: Uint8Array};
+    finalizedCheckpoint: {epoch: number; root: Uint8Array};
+    currentSyncCommittee: {aggregatePubkey: Uint8Array};
+    nextSyncCommittee: {aggregatePubkey: Uint8Array};
     latestExecutionPayloadHeader: {
       blockNumber: number;
       blockHash: Uint8Array;
@@ -586,7 +586,7 @@ describe("BeaconStateView", () => {
 
     it("processSlots with dontTransferCache: false should still transfer cache", () => {
       const originalSlot = state.slot;
-      const newState = state.processSlots(originalSlot + 1, { dontTransferCache: false });
+      const newState = state.processSlots(originalSlot + 1, {dontTransferCache: false});
 
       expect(newState.slot).toBe(originalSlot + 1);
       expect(newState.createdWithTransferCache).toBe(false);

--- a/src/state_transition/utils/balance.zig
+++ b/src/state_transition/utils/balance.zig
@@ -26,6 +26,8 @@ pub fn decreaseBalance(comptime fork: ForkSeq, state: *BeaconState(fork), index:
 pub fn getEffectiveBalanceIncrementsZeroInactive(allocator: Allocator, cached_state: *CachedBeaconState) !EffectiveBalanceIncrements {
     const active_indices = cached_state.epoch_cache.getCurrentShuffling().active_indices;
     // 5x faster than reading from state.validators, with validator Nodes as values
+
+    try cached_state.state.commit();
     const validators = try cached_state.state.validatorsSlice(allocator);
     defer allocator.free(validators);
     const validator_count = validators.len;


### PR DESCRIPTION
despite the double negation being confusing we're still on `dontTransferCache` on lodestar, so this change is just to reduce the diff surface when integrating bindings there.

We should switch back to `transferCache` for clearer naming once  native state transition is integrated.