### PR TITLE
refactor(bindings): align `StateTransitionOpts` bindings parsing with ts version

### DIFF
--- a/bindings/napi/stateTransition.zig
+++ b/bindings/napi/stateTransition.zig
@@ -44,29 +44,29 @@ fn parseOptions(options: ?js.Value) !st.TransitionOpts {
             }
             if (try raw.hasNamedProperty("executionPayloadStatus")) {
                 var buf: [16]u8 = undefined;
-                const s = try (try raw.getNamedProperty("executionPayloadStatus")).getValueStringUtf8(&buf);
+                const execution_payload_status = try (try raw.getNamedProperty("executionPayloadStatus")).getValueStringUtf8(&buf);
                 transition_opts.block_external_data.execution_payload_status =
-                    if (std.mem.eql(u8, s, "valid"))
+                    if (std.mem.eql(u8, execution_payload_status, "valid"))
                         .valid
-                    else if (std.mem.eql(u8, s, "invalid"))
+                    else if (std.mem.eql(u8, execution_payload_status, "invalid"))
                         .invalid
-                    else if (std.mem.eql(u8, s, "preMerge"))
+                    else if (std.mem.eql(u8, execution_payload_status, "preMerge"))
                         .pre_merge
                     else
                         return error.InvalidExecutionPayloadStatus;
             }
             if (try raw.hasNamedProperty("dataAvailabilityStatus")) {
                 var buf: [16]u8 = undefined;
-                const s = try (try raw.getNamedProperty("dataAvailabilityStatus")).getValueStringUtf8(&buf);
+                const da_status = try (try raw.getNamedProperty("dataAvailabilityStatus")).getValueStringUtf8(&buf);
                 transition_opts.block_external_data.data_availability_status =
-                    if (std.mem.eql(u8, s, "Available"))
+                    if (std.mem.eql(u8, da_status, "Available"))
                         .available
-                    else if (std.mem.eql(u8, s, "PreData"))
+                    else if (std.mem.eql(u8, da_status, "PreData"))
                         .pre_data
-                    else if (std.mem.eql(u8, s, "OutOfRange"))
+                    else if (std.mem.eql(u8, da_status, "OutOfRange"))
                         .out_of_range
                         // TODO(bing): uncomment once gloas support is in
-                        // else if (std.mem.eql(u8, s, "NotRequired")) .not_required;
+                        // else if (std.mem.eql(u8, da_status, "NotRequired")) .not_required;
                     else
                         return error.InvalidDataAvailabilityStatus;
             }

--- a/bindings/napi/stateTransition.zig
+++ b/bindings/napi/stateTransition.zig
@@ -15,35 +15,64 @@ const allocator = if (builtin.mode == .Debug)
 else
     std.heap.c_allocator;
 
-/// Parse a JS options object into Zig's TransitionOpt.
+/// Parse a JS options object into Zig's TransitionOpts.
 ///
 /// Recognized fields:
 /// - verifyStateRoot, verifyProposer, verifySignatures: bool
 /// - dontTransferCache: bool (negated to set transfer_cache)
+/// - executionPayloadStatus: "valid" | "invalid" | "preMerge"
+/// - dataAvailabilityStatus: "Available" | "PreData" | "OutOfRange"
 ///
 /// This is the double negative version to conform with production lodestar.
 /// TODO(bing): Eventually rename this to `transferCache` to avoid double negation because its confusing naming.
-/// TODO(bing): Other fields (executionPayloadStatus, ..).
-fn parseOptions(options: ?js.Value) !st.TransitionOpt {
-    var transit_options: st.TransitionOpt = .{};
+fn parseOptions(options: ?js.Value) !st.TransitionOpts {
+    var transition_opts: st.TransitionOpts = .{};
     if (options) |value| {
         const raw = value.toValue();
         if (try raw.typeof() == .object) {
             if (try raw.hasNamedProperty("verifyStateRoot")) {
-                transit_options.verify_state_root = try (try raw.getNamedProperty("verifyStateRoot")).getValueBool();
+                transition_opts.verify_state_root = try (try raw.getNamedProperty("verifyStateRoot")).getValueBool();
             }
             if (try raw.hasNamedProperty("verifyProposer")) {
-                transit_options.verify_proposer = try (try raw.getNamedProperty("verifyProposer")).getValueBool();
+                transition_opts.verify_proposer = try (try raw.getNamedProperty("verifyProposer")).getValueBool();
             }
             if (try raw.hasNamedProperty("verifySignatures")) {
-                transit_options.verify_signatures = try (try raw.getNamedProperty("verifySignatures")).getValueBool();
+                transition_opts.verify_signatures = try (try raw.getNamedProperty("verifySignatures")).getValueBool();
             }
             if (try raw.hasNamedProperty("dontTransferCache")) {
-                transit_options.transfer_cache = !(try (try raw.getNamedProperty("dontTransferCache")).getValueBool());
+                transition_opts.transfer_cache = !(try (try raw.getNamedProperty("dontTransferCache")).getValueBool());
+            }
+            if (try raw.hasNamedProperty("executionPayloadStatus")) {
+                var buf: [16]u8 = undefined;
+                const s = try (try raw.getNamedProperty("executionPayloadStatus")).getValueStringUtf8(&buf);
+                transition_opts.block_external_data.execution_payload_status =
+                    if (std.mem.eql(u8, s, "valid"))
+                        .valid
+                    else if (std.mem.eql(u8, s, "invalid"))
+                        .invalid
+                    else if (std.mem.eql(u8, s, "preMerge"))
+                        .pre_merge
+                    else
+                        return error.InvalidExecutionPayloadStatus;
+            }
+            if (try raw.hasNamedProperty("dataAvailabilityStatus")) {
+                var buf: [16]u8 = undefined;
+                const s = try (try raw.getNamedProperty("dataAvailabilityStatus")).getValueStringUtf8(&buf);
+                transition_opts.block_external_data.data_availability_status =
+                    if (std.mem.eql(u8, s, "Available"))
+                        .available
+                    else if (std.mem.eql(u8, s, "PreData"))
+                        .pre_data
+                    else if (std.mem.eql(u8, s, "OutOfRange"))
+                        .out_of_range
+                        // TODO(bing): uncomment once gloas support is in
+                        // else if (std.mem.eql(u8, s, "NotRequired")) .not_required;
+                    else
+                        return error.InvalidDataAvailabilityStatus;
             }
         }
     }
-    return transit_options;
+    return transition_opts;
 }
 
 /// Perform a state transition given a signed beacon block.
@@ -65,6 +94,7 @@ pub fn stateTransition(
     const env = js.env();
     const pre_state = pre_state_value.toValue();
     const cached_state = try env.unwrap(CachedBeaconState, pre_state);
+    const transition_opts = try parseOptions(options);
     const signed_block_bytes_slice = try signed_block_bytes.toSlice();
 
     const current_epoch = st.computeEpochAtSlot(try cached_state.state.slot());
@@ -82,7 +112,7 @@ pub fn stateTransition(
         napi_io.get(),
         cached_state,
         signed_block,
-        try parseOptions(options),
+        transition_opts,
     );
     errdefer {
         post_state.deinit();

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -597,13 +597,13 @@ describe("BeaconStateView", () => {
     const dummyBlockBytes = new Uint8Array(0);
 
     it("rejects invalid opts", () => {
-      const invalid_opts = [
+      const invalidOpts = [
         {executionPayloadStatus: "syncing"},
         {dataAvailabilityStatus: "Whatever"},
         {executionPayloadStatus: "Valid"}, // TS enum value is "valid"
         {dataAvailabilityStatus: "available"}, // TS enum value is "Available"
       ];
-      for (const opts of invalid_opts) {
+      for (const opts of invalidOpts) {
         expect(() => bindings.stateTransition.stateTransition(state, dummyBlockBytes, opts)).toThrow();
       }
     });

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -593,6 +593,29 @@ describe("BeaconStateView", () => {
     });
   });
 
+  describe("stateTransition parseOptions", () => {
+    const dummyBlockBytes = new Uint8Array(0);
+
+    it("rejects invalid opts", () => {
+      const invalid_opts = [
+        {executionPayloadStatus: "syncing"},
+        {dataAvailabilityStatus: "Whatever"},
+        {executionPayloadStatus: "Valid"}, // TS enum value is "valid"
+        {dataAvailabilityStatus: "available"}, // TS enum value is "Available"
+      ];
+      for (const opts of invalid_opts) {
+        expect(() => bindings.stateTransition.stateTransition(state, dummyBlockBytes, opts)).toThrow();
+      }
+    });
+
+    // TODO: remove once Zig models DataAvailabilityStatus.NotRequired
+    it("rejects gloas-only NotRequired", () => {
+      expect(() =>
+        bindings.stateTransition.stateTransition(state, dummyBlockBytes, {dataAvailabilityStatus: "NotRequired"})
+      ).toThrow();
+    });
+  });
+
   describe("effective balance increments", () => {
     it("getEffectiveBalanceIncrementsZeroInactive should return Uint16Array", () => {
       const increments = state.getEffectiveBalanceIncrementsZeroInactive();

--- a/src/state_transition/root.zig
+++ b/src/state_transition/root.zig
@@ -3,7 +3,7 @@ const testing = std.testing;
 
 pub const stateTransition = @import("state_transition.zig").stateTransition;
 pub const processSlots = @import("state_transition.zig").processSlots;
-pub const TransitionOpt = @import("state_transition.zig").TransitionOpt;
+pub const TransitionOpts = @import("state_transition.zig").TransitionOpts;
 
 pub const metrics = @import("metrics.zig");
 
@@ -98,6 +98,8 @@ pub const bls = @import("utils/bls.zig");
 const seed = @import("./utils/seed.zig");
 pub const state_transition = @import("./state_transition.zig");
 pub const BlockExternalData = state_transition.BlockExternalData;
+pub const ExecutionPayloadStatus = state_transition.ExecutionPayloadStatus;
+pub const DataAvailabilityStatus = state_transition.DataAvailabilityStatus;
 pub const preset = @import("preset").preset;
 const EpochShuffling = @import("./utils/epoch_shuffling.zig");
 pub const calculateShufflingDecisionRoot = EpochShuffling.calculateShufflingDecisionRoot;

--- a/src/state_transition/state_transition.zig
+++ b/src/state_transition/state_transition.zig
@@ -36,13 +36,15 @@ pub const ExecutionPayloadStatus = enum(u8) {
     valid,
 };
 
+pub const DataAvailabilityStatus = enum(u8) {
+    pre_data,
+    out_of_range,
+    available,
+};
+
 pub const BlockExternalData = struct {
-    execution_payload_status: ExecutionPayloadStatus,
-    data_availability_status: enum(u8) {
-        pre_data,
-        out_of_range,
-        available,
-    },
+    execution_payload_status: ExecutionPayloadStatus = .valid,
+    data_availability_status: DataAvailabilityStatus = .available,
 };
 
 pub fn processSlots(
@@ -139,12 +141,13 @@ pub fn processSlots(
     }
 }
 
-pub const TransitionOpt = struct {
+pub const TransitionOpts = struct {
     verify_state_root: bool = true,
     verify_proposer: bool = true,
     /// NOTE: verifying BLS signatures is expensive - make sure to turn this off for tests.
     verify_signatures: bool = true,
     transfer_cache: bool = true,
+    block_external_data: BlockExternalData = .{},
 };
 
 pub const StateTransitionResult = struct {
@@ -162,7 +165,7 @@ pub fn stateTransition(
     io: std.Io,
     cached_state: *CachedBeaconState,
     signed_block: AnySignedBeaconBlock,
-    opts: TransitionOpt,
+    opts: TransitionOpts,
 ) !*CachedBeaconState {
     const block = signed_block.beaconBlock();
     const block_slot = block.slot();
@@ -221,10 +224,7 @@ pub fn stateTransition(
                         &post_cached_state.slashings_cache,
                         bt,
                         block.castToFork(bt, f),
-                        BlockExternalData{
-                            .execution_payload_status = .valid,
-                            .data_availability_status = .available,
-                        },
+                        opts.block_external_data,
                         .{ .verify_signature = opts.verify_signatures },
                     );
                 },
@@ -264,7 +264,7 @@ pub fn deinitStateTransition(io: std.Io) void {
 }
 
 const TestCase = struct {
-    transition_opt: TransitionOpt,
+    transition_opt: TransitionOpts,
     expect_error: bool,
 };
 


### PR DESCRIPTION


We need to parse `BlockExternalData` via `parseOptions` and pass it into the native stf.

See: https://github.com/ChainSafe/lodestar/blob/35940ffd61ad7e29f5de376e13587d044b27b246/packages/state-transition/src/stateTransition.ts#L36