### PR TITLE
fix(bindings): refcount Pool to fix teardown panic

### DIFF
--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -66,10 +66,6 @@ pub const js_meta = js.class(.{ .properties = .{
 } });
 
 cached_state: ?*CachedBeaconState = null,
-/// Holds a strong reference to the shared `Node.Pool` for the lifetime of
-/// `cached_state`. Released in `deinit` AFTER `cached_state.deinit` finishes
-/// its `pool.unref` calls, so the pool stays alive even if the module's
-/// NAPI env cleanup hook fired before this view's JS finalizer.
 pool_rc: ?*pool.PoolRc = null,
 const BeaconStateView = @This();
 

--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -66,6 +66,11 @@ pub const js_meta = js.class(.{ .properties = .{
 } });
 
 cached_state: ?*CachedBeaconState = null,
+/// Holds a strong reference to the shared `Node.Pool` for the lifetime of
+/// `cached_state`. Released in `deinit` AFTER `cached_state.deinit` finishes
+/// its `pool.unref` calls, so the pool stays alive even if the module's
+/// NAPI env cleanup hook fired before this view's JS finalizer.
+pool_rc: ?*pool.PoolRc = null,
 const BeaconStateView = @This();
 
 pub fn init() BeaconStateView {
@@ -77,6 +82,10 @@ pub fn deinit(self: *BeaconStateView) void {
         cached_state.deinit();
         allocator.destroy(cached_state);
         self.cached_state = null;
+    }
+    if (self.pool_rc) |rc| {
+        rc.unref();
+        self.pool_rc = null;
     }
 }
 
@@ -90,7 +99,7 @@ pub fn createFromBytes(bytes: js.Uint8Array) !BeaconStateView {
     const byte_slice = try bytes.toSlice();
     const slot_value = fork_types.readSlotFromAnyBeaconStateBytes(byte_slice);
     const fork_seq = config.state.config.forkSeq(slot_value);
-    state.* = try AnyBeaconState.deserialize(allocator, &pool.state.pool, fork_seq, byte_slice);
+    state.* = try AnyBeaconState.deserialize(allocator, pool.state.pool(), fork_seq, byte_slice);
     errdefer state.deinit();
 
     const cached_state = try allocator.create(CachedBeaconState);
@@ -107,7 +116,10 @@ pub fn createFromBytes(bytes: js.Uint8Array) !BeaconStateView {
         null,
     );
 
-    return .{ .cached_state = cached_state };
+    return .{
+        .cached_state = cached_state,
+        .pool_rc = pool.state.poolRc().ref(),
+    };
 }
 
 // -------------------------
@@ -781,7 +793,7 @@ pub fn createMultiProof(self: *const BeaconStateView, descriptor: js.Uint8Array)
 
     var proof = persistent_merkle_tree.proof.createProof(
         allocator,
-        &pool.state.pool,
+        pool.state.pool(),
         root_node,
         proof_input,
     ) catch {
@@ -934,7 +946,10 @@ pub fn processSlots(self: *const BeaconStateView, slot_arg: js.Number, options: 
     }
 
     try st.processSlots(allocator, napi_io.get(), post_state, slot_value, .{});
-    return .{ .cached_state = post_state };
+    return .{
+        .cached_state = post_state,
+        .pool_rc = pool.state.poolRc().ref(),
+    };
 }
 
 /// Compute expected withdrawals for the next payload (capella+).

--- a/bindings/napi/pool.zig
+++ b/bindings/napi/pool.zig
@@ -11,6 +11,11 @@ const default_pool_size: u32 = 0;
 
 pub const PoolRc = RefCount(Node.Pool);
 
+/// Pool is wrapped in `RefCount` so binding objects holding pool refs at
+/// process exit keep the pool alive until their JS finalizer runs. NAPI
+/// env cleanup hook fires before module-level JS holders are finalized,
+/// so an unconditional `pool.deinit()` there would free memory that
+/// `pool.unref()` calls in those finalizers still need.
 pub const State = struct {
     pool_rc: ?*PoolRc = null,
 

--- a/bindings/napi/pool.zig
+++ b/bindings/napi/pool.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const js = @import("zapi:zapi").js;
 const Node = @import("persistent_merkle_tree").Node;
+const RefCount = @import("state_transition").RefCount;
 
 /// Pool uses page allocator for internal allocations.
 /// It's recommended to never reallocate the pool after initialization.
@@ -8,20 +9,40 @@ const allocator = std.heap.page_allocator;
 
 const default_pool_size: u32 = 0;
 
+pub const PoolRc = RefCount(Node.Pool);
+
+/// Pool is wrapped in `RefCount` so that any `BeaconStateView` (or other
+/// binding object) holding pool references at process exit keeps the pool
+/// alive until its own JS finalizer runs. Without this, NAPI env cleanup
+/// can run before module-level JS holders are finalized, freeing the pool
+/// before the holder's `pool.unref()` calls — causing "incorrect alignment"
+/// panics during teardown.
 pub const State = struct {
-    pool: Node.Pool = undefined,
-    initialized: bool = false,
+    pool_rc: ?*PoolRc = null,
 
     pub fn init(self: *State) !void {
-        if (self.initialized) return;
-        self.pool = try Node.Pool.init(allocator, default_pool_size);
-        self.initialized = true;
+        if (self.pool_rc != null) return;
+        var pool_value = try Node.Pool.init(allocator, default_pool_size);
+        errdefer pool_value.deinit();
+        self.pool_rc = try PoolRc.init(allocator, pool_value);
     }
 
+    /// Drops the module's reference. Pool is actually destroyed when the
+    /// last live reference is released (could be here or in a later
+    /// BeaconStateView finalizer).
     pub fn deinit(self: *State) void {
-        if (!self.initialized) return;
-        self.pool.deinit();
-        self.initialized = false;
+        if (self.pool_rc) |rc| {
+            rc.unref();
+            self.pool_rc = null;
+        }
+    }
+
+    pub fn pool(self: *State) *Node.Pool {
+        return &self.pool_rc.?.instance;
+    }
+
+    pub fn poolRc(self: *State) *PoolRc {
+        return self.pool_rc.?;
     }
 };
 
@@ -29,14 +50,14 @@ pub var state: State = .{};
 
 /// JS: pool.ensureCapacity(newSize)
 pub fn ensureCapacity(new_size: js.Number) !void {
-    if (!state.initialized) {
+    if (state.pool_rc == null) {
         return error.PoolNotInitialized;
     }
 
     const requested = new_size.assertU32();
-    const old_size = state.pool.nodes.capacity;
+    const old_size = state.pool().nodes.capacity;
     if (requested <= old_size) {
         return;
     }
-    try state.pool.preheat(@intCast(requested - state.pool.nodes.capacity));
+    try state.pool().preheat(@intCast(requested - state.pool().nodes.capacity));
 }

--- a/bindings/napi/pool.zig
+++ b/bindings/napi/pool.zig
@@ -34,10 +34,12 @@ pub const State = struct {
     }
 
     pub fn pool(self: *State) *Node.Pool {
+        std.debug.assert(self.pool_rc != null);
         return &self.pool_rc.?.instance;
     }
 
     pub fn poolRc(self: *State) *PoolRc {
+        std.debug.assert(self.pool_rc != null);
         return self.pool_rc.?;
     }
 };

--- a/bindings/napi/pool.zig
+++ b/bindings/napi/pool.zig
@@ -11,12 +11,6 @@ const default_pool_size: u32 = 0;
 
 pub const PoolRc = RefCount(Node.Pool);
 
-/// Pool is wrapped in `RefCount` so that any `BeaconStateView` (or other
-/// binding object) holding pool references at process exit keeps the pool
-/// alive until its own JS finalizer runs. Without this, NAPI env cleanup
-/// can run before module-level JS holders are finalized, freeing the pool
-/// before the holder's `pool.unref()` calls — causing "incorrect alignment"
-/// panics during teardown.
 pub const State = struct {
     pool_rc: ?*PoolRc = null,
 
@@ -27,9 +21,6 @@ pub const State = struct {
         self.pool_rc = try PoolRc.init(allocator, pool_value);
     }
 
-    /// Drops the module's reference. Pool is actually destroyed when the
-    /// last live reference is released (could be here or in a later
-    /// BeaconStateView finalizer).
     pub fn deinit(self: *State) void {
         if (self.pool_rc) |rc| {
             rc.unref();

--- a/bindings/test/teardown.test.ts
+++ b/bindings/test/teardown.test.ts
@@ -1,5 +1,5 @@
 import {spawnSync} from "node:child_process";
-import {writeFileSync, unlinkSync} from "node:fs";
+import {unlinkSync, writeFileSync} from "node:fs";
 import {join} from "node:path";
 import {describe, expect, it} from "vitest";
 
@@ -27,15 +27,15 @@ bindings.pubkeys.ensureCapacity(2_000_000);
 
 const seedState = bindings.BeaconStateView.createFromBytes(stateBytes);
 console.log("slot=" + seedState.slot);
-`,
+`
     );
 
     try {
-      const result = spawnSync(
-        process.execPath,
-        ["--experimental-strip-types", fixturePath],
-        {encoding: "utf-8", cwd: projectRoot, timeout: 60_000},
-      );
+      const result = spawnSync(process.execPath, ["--experimental-strip-types", fixturePath], {
+        cwd: projectRoot,
+        encoding: "utf-8",
+        timeout: 60_000,
+      });
       expect(result.status, `stdout=${result.stdout} stderr=${result.stderr}`).toBe(0);
       expect(result.stderr, "no panic on stderr").not.toContain("panic:");
     } finally {

--- a/bindings/test/teardown.test.ts
+++ b/bindings/test/teardown.test.ts
@@ -1,0 +1,53 @@
+import {spawnSync} from "node:child_process";
+import {writeFileSync, unlinkSync} from "node:fs";
+import {tmpdir} from "node:os";
+import {join} from "node:path";
+import {describe, expect, it} from "vitest";
+
+describe("BeaconStateView teardown", () => {
+  it("creates view at module scope and exits cleanly", () => {
+    const projectRoot = join(import.meta.dirname, "../..");
+    const fixturePath = join(tmpdir(), `lodestar-z-teardown-${process.pid}.mjs`);
+
+    // Module-scope `const seedState = ...` mirrors how perf bench files
+    // hold native objects. Without the Pool refcount fix, NAPI env cleanup
+    // frees the pool before this view's finalizer runs, and the chained
+    // pool.unref calls panic with "incorrect alignment" on process exit
+    // (exit code 134 / SIGABRT).
+    writeFileSync(
+      fixturePath,
+      `
+import {config} from "@lodestar/config/default";
+import * as era from "@lodestar/era";
+import bindings from "${projectRoot}/bindings/src/index.js";
+import {getFirstEraFilePath} from "${projectRoot}/bindings/test/eraFiles.ts";
+
+const reader = await era.era.EraReader.open(config, getFirstEraFilePath());
+const stateBytes = await reader.readSerializedState();
+await reader.close();
+
+bindings.pool.ensureCapacity(10_000_000);
+bindings.pubkeys.ensureCapacity(2_000_000);
+
+const seedState = bindings.BeaconStateView.createFromBytes(stateBytes);
+console.log("slot=" + seedState.slot);
+`,
+    );
+
+    try {
+      const result = spawnSync(
+        process.execPath,
+        ["--experimental-strip-types", fixturePath],
+        {encoding: "utf-8", cwd: projectRoot, timeout: 60_000},
+      );
+      expect(result.status, `stdout=${result.stdout} stderr=${result.stderr}`).toBe(0);
+      expect(result.stderr, "no panic on stderr").not.toContain("panic:");
+    } finally {
+      try {
+        unlinkSync(fixturePath);
+      } catch (_e) {
+        // ignore
+      }
+    }
+  }, 90_000);
+});

--- a/bindings/test/teardown.test.ts
+++ b/bindings/test/teardown.test.ts
@@ -1,13 +1,14 @@
 import {spawnSync} from "node:child_process";
 import {writeFileSync, unlinkSync} from "node:fs";
-import {tmpdir} from "node:os";
 import {join} from "node:path";
 import {describe, expect, it} from "vitest";
 
 describe("BeaconStateView teardown", () => {
   it("creates view at module scope and exits cleanly", () => {
     const projectRoot = join(import.meta.dirname, "../..");
-    const fixturePath = join(tmpdir(), `lodestar-z-teardown-${process.pid}.mjs`);
+    // Fixture must live under the project root so Node resolves its
+    // node_modules from there (workspace packages like @lodestar/config).
+    const fixturePath = join(projectRoot, `bindings/test/.tmp-teardown-${process.pid}.mjs`);
 
     // Module-scope `const seedState = ...` mirrors how perf bench files
     // hold native objects. Without the Pool refcount fix, NAPI env cleanup
@@ -19,8 +20,8 @@ describe("BeaconStateView teardown", () => {
       `
 import {config} from "@lodestar/config/default";
 import * as era from "@lodestar/era";
-import bindings from "${projectRoot}/bindings/src/index.js";
-import {getFirstEraFilePath} from "${projectRoot}/bindings/test/eraFiles.ts";
+import bindings from "../src/index.js";
+import {getFirstEraFilePath} from "./eraFiles.ts";
 
 const reader = await era.era.EraReader.open(config, getFirstEraFilePath());
 const stateBytes = await reader.readSerializedState();

--- a/bindings/test/teardown.test.ts
+++ b/bindings/test/teardown.test.ts
@@ -6,15 +6,10 @@ import {describe, expect, it} from "vitest";
 describe("BeaconStateView teardown", () => {
   it("creates view at module scope and exits cleanly", () => {
     const projectRoot = join(import.meta.dirname, "../..");
-    // Fixture must live under the project root so Node resolves its
-    // node_modules from there (workspace packages like @lodestar/config).
+    // Fixture must live under the project root so Node resolves
+    // workspace packages like @lodestar/config from local node_modules.
     const fixturePath = join(projectRoot, `bindings/test/.tmp-teardown-${process.pid}.mjs`);
 
-    // Module-scope `const seedState = ...` mirrors how perf bench files
-    // hold native objects. Without the Pool refcount fix, NAPI env cleanup
-    // frees the pool before this view's finalizer runs, and the chained
-    // pool.unref calls panic with "incorrect alignment" on process exit
-    // (exit code 134 / SIGABRT).
     writeFileSync(
       fixturePath,
       `

--- a/src/state_transition/root.zig
+++ b/src/state_transition/root.zig
@@ -7,6 +7,7 @@ pub const TransitionOpts = @import("state_transition.zig").TransitionOpts;
 
 pub const metrics = @import("metrics.zig");
 
+pub const RefCount = @import("./utils/ref_count.zig").RefCount;
 pub const computeSigningRoot = @import("./utils/signing_root.zig").computeSigningRoot;
 pub const computeEpochAtSlot = @import("./utils/epoch.zig").computeEpochAtSlot;
 pub const CachedBeaconState = @import("./cache/state_cache.zig").CachedBeaconState;


### PR DESCRIPTION
## Motivation

Reproduces on `main` and every binding-feature branch (#165, #346, #351): any process that holds a `BeaconStateView` at module scope panics during process exit:

```
thread N panic: incorrect alignment
src/persistent_merkle_tree/Node.zig:387:9 in unref
src/ssz/tree_view/chunks.zig:38:30 in deinit
src/ssz/tree_view/container.zig:97:49 in clearChildrenDataCache
src/state_transition/cache/state_cache.zig:102:26 in deinit
```

Process exits with code 134 (SIGABRT) instead of 0.

Root cause: NAPI env cleanup hook (`napi_add_env_cleanup_hook`) fires before module-level JS holders of native objects are finalized. The previous `cleanup` callback unconditionally called `pool.state.deinit()`, freeing the `Node.Pool`'s `MultiArrayList` storage. Live `BeaconStateView` instances rooted by module-level `const` had not yet been finalized; when their finalizers eventually ran, the chained `pool.unref(self.root)` walked freed memory and panicked.

Module-scope is the standard pattern for benchmark fixtures (`@chainsafe/benchmark` + perf tests). Without the fix, every such test exits non-zero even when the bench itself succeeds.

## Description

Wrap `Node.Pool` in the existing `RefCount(T)` (`src/state_transition/utils/ref_count.zig`):

- Module init holds `ref = 1`.
- Each `BeaconStateView` that owns a `cached_state` holds another ref.
- `pool.state.deinit()` releases the module ref but only actually destroys the pool when the count reaches zero — deferring destruction past every live view's finalizer.

Order in `BeaconStateView.deinit`:
1. `cached_state.deinit()` — does all the `pool.unref(...)` calls
2. `pool_rc.unref()` — releases this view's pool ref; if last, real `pool.deinit` runs here