### PR TITLE
feat(ci): conditionally publish bindings with tag

### DIFF
--- a/.github/workflows/publish-bindings.yml
+++ b/.github/workflows/publish-bindings.yml
@@ -44,9 +44,23 @@ jobs:
       - name: Run bindings formatter
         run: |
           pnpm biome ci
+      - name: Determine npm dist tag
+        id: detect_dist_tag 
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            # Prerelease: derive tag from the prerelease identifier (e.g. 0.1.2-rc.0 -> rc)
+            TAG="${VERSION#*-}"
+            TAG="${TAG%%.*}"
+            echo "Prerelease version $VERSION.$TAG"
+            echo "tag_flag=--tag $TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "Stable version $VERSION -> npm default dist-tag"
+            echo "tag_flag=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build and publish to npm
         run: |
           pnpm zapi build-artifacts --optimize ReleaseSafe
           pnpm zapi prepublish
-          pnpm zapi publish --access public -- --provenance
+          pnpm zapi publish --access public -- --provenance ${{ steps.detect_dist_tag.outputs.tag_flag }}
 


### PR DESCRIPTION
Pre-release versions need a `--tag` flag. See
https://github.com/ChainSafe/lodestar-z/actions/runs/25559350998/job/75026549721