### PR TITLE
refactor(bindings): wake only required number of workers

### DIFF
--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -60,6 +60,7 @@ const JobQueue = struct {
     cond: std.Io.Condition = std.Io.Condition.init,
     head: ?*WorkItem = null,
     tail: ?*WorkItem = null,
+    sleeping_workers: usize = 0,
 
     /// Pushes a batch of `WorkItem`s to the `JobQueue`.
     ///
@@ -80,7 +81,7 @@ const JobQueue = struct {
             }
             self.tail = item;
         }
-        for (0..@min(items.len, pool.n_workers)) |_| {
+        for (0..@min(items.len, self.sleeping_workers)) |_| {
             self.cond.signal(io);
         }
         return true;
@@ -163,7 +164,9 @@ fn workerLoop(pool: *ThreadPool, io: std.Io) void {
             while (true) {
                 if (pool.queue.pop()) |wi| break :blk wi;
                 if (pool.shutdown.load(.acquire)) return;
+                pool.queue.sleeping_workers += 1;
                 pool.queue.cond.waitUncancelable(io, &pool.queue.mutex);
+                pool.queue.sleeping_workers -= 1;
             }
         };
 

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -80,7 +80,9 @@ const JobQueue = struct {
             }
             self.tail = item;
         }
-        self.cond.broadcast(io);
+        for (0..@min(items.len, pool.n_workers)) |_| {
+            self.cond.signal(io);
+        }
         return true;
     }
 

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -60,6 +60,10 @@ const JobQueue = struct {
     cond: std.Io.Condition = std.Io.Condition.init,
     head: ?*WorkItem = null,
     tail: ?*WorkItem = null,
+    /// Count of workers currently blocked in `cond.wait`. Guarded by `mutex`
+    /// (read in `pushBatch`, maintained in `workerLoop`), so it is exact at
+    /// signal time. Lets `pushBatch` wake only as many workers as there is new
+    /// work for, instead of broadcasting to all of them.
     sleeping_workers: usize = 0,
 
     /// Pushes a batch of `WorkItem`s to the `JobQueue`.

--- a/src/bls/ThreadPool.zig
+++ b/src/bls/ThreadPool.zig
@@ -85,6 +85,10 @@ const JobQueue = struct {
             }
             self.tail = item;
         }
+        // Wake at most one sleeping worker per submitted item, and never more than
+        // are actually asleep. Running workers loop back to `pop()` after each item,
+        // so signals are only needed to bring sleeping workers back into the queue;
+        // extra signals only create scheduler churn.
         for (0..@min(items.len, self.sleeping_workers)) |_| {
             self.cond.signal(io);
         }


### PR DESCRIPTION
introduces

- `sleeping_workers`: mark itself as asleep when no work is available, mark itself as not a `sleeping_worker` (i.e. `sleeping_workers -= 1` when it sees work
- use `signal` instead of `broadcast`

I suspect contention on threads causing regression on bls workload. This at least metrics wise on `feat3-sas` has some good effects (white line is redeployment):

<img width="1656" height="446" alt="Screenshot 2026-05-28 at 9 30 20 PM" src="https://github.com/user-attachments/assets/2b06593d-f331-45ce-9a87-be9d35952fd8" />

Job wait time is also trending down:

<img width="1691" height="450" alt="Screenshot 2026-05-28 at 9 32 18 PM" src="https://github.com/user-attachments/assets/d3de0992-37cb-49fa-a5c3-9f3a23506122" />
