### PR TITLE
fix: do not set start index for deposit request in non-electra forks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -123,6 +123,8 @@ jobs:
   spec-test-prep:
     name: spec tests - prepare
     runs-on: ubuntu-latest
+    outputs:
+      spec-test-version: ${{ steps.spec-test-version.outputs.version }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -131,11 +133,24 @@ jobs:
         with:
           version: ${{ env.ZIG_VERSION }}
           cache-key: ubuntu-latest-${{ env.ZIG_VERSION }}
+      - name: Read spec test version
+        id: spec-test-version
+        run: |
+          version=$(awk '
+            /\.spec_test_version = \./ {in_block=1}
+            in_block && /\.default = / {
+              match($0, /"[^"]+"/)
+              print substr($0, RSTART + 1, RLENGTH - 2)
+              exit
+            }
+          ' build.zig.zon)
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Restore spec tests cache
         uses: actions/cache@v4
         with:
           path: test/spec/spec_tests
-          key: spec-test-data-${{ hashFiles('build.zig') }} # spec test version is defined in build.zig
+          key: spec-test-data-${{ steps.spec-test-version.outputs.version }}
       - name: Download spec tests
         run: |
           zig build run:download_spec_tests
@@ -179,7 +194,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test/spec/spec_tests
-          key: spec-test-data-${{ hashFiles('build.zig') }}
+          key: spec-test-data-${{ needs['spec-test-prep'].outputs['spec-test-version'] }}
       - name: Download generated test files
         uses: actions/download-artifact@v4
         with:
@@ -205,7 +220,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test/spec/spec_tests
-          key: spec-test-data-${{ hashFiles('build.zig') }}
+          key: spec-test-data-${{ needs['spec-test-prep'].outputs['spec-test-version'] }}
       - name: Download generated test files
         uses: actions/download-artifact@v4
         with:
@@ -231,7 +246,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test/spec/spec_tests
-          key: spec-test-data-${{ hashFiles('build.zig') }}
+          key: spec-test-data-${{ needs['spec-test-prep'].outputs['spec-test-version'] }}
       - name: Download generated test files
         uses: actions/download-artifact@v4
         with:
@@ -257,7 +272,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test/spec/spec_tests
-          key: spec-test-data-${{ hashFiles('build.zig') }}
+          key: spec-test-data-${{ needs['spec-test-prep'].outputs['spec-test-version'] }}
       - name: Download generated test files
         uses: actions/download-artifact@v4
         with:
@@ -296,7 +311,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test/spec/spec_tests
-          key: spec-test-data-${{ hashFiles('build.zig') }}
+          key: spec-test-data-${{ needs['spec-test-prep'].outputs['spec-test-version'] }}
       - name: Download generated test files
         uses: actions/download-artifact@v4
         with:
@@ -335,7 +350,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: test/spec/spec_tests
-          key: spec-test-data-${{ hashFiles('build.zig') }}
+          key: spec-test-data-${{ needs['spec-test-prep'].outputs['spec-test-version'] }}
       - name: Download generated test files
         uses: actions/download-artifact@v4
         with:

--- a/src/state_transition/block/process_deposit_request.zig
+++ b/src/state_transition/block/process_deposit_request.zig
@@ -6,9 +6,11 @@ const PendingDeposit = types.electra.PendingDeposit.Type;
 const c = @import("constants");
 
 pub fn processDepositRequest(comptime fork: ForkSeq, state: *BeaconState(fork), deposit_request: *const DepositRequest) !void {
-    const deposit_requests_start_index = try state.depositRequestsStartIndex();
-    if (deposit_requests_start_index == c.UNSET_DEPOSIT_REQUESTS_START_INDEX) {
-        try state.setDepositRequestsStartIndex(deposit_request.index);
+    if (comptime fork == .electra) {
+        const deposit_requests_start_index = try state.depositRequestsStartIndex();
+        if (deposit_requests_start_index == c.UNSET_DEPOSIT_REQUESTS_START_INDEX) {
+            try state.setDepositRequestsStartIndex(deposit_request.index);
+        }
     }
 
     const pending_deposit = PendingDeposit{


### PR DESCRIPTION
This was causing a spec test failure

See: https://github.com/ChainSafe/lodestar/blob/f6b2af6879db8092cdaf0dad41b3a098ff391a4a/packages/state-transition/src/block/processDepositRequest.ts#L133