### PR TITLE
chore: update spec-test-version: v1.6.0-beta.2 -> v1.7.0-alpha.10

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -105,7 +105,7 @@
             },
             .spec_test_version = .{
                 .type = .string,
-                .default = "v1.6.0-beta.2",
+                .default = "v1.7.0-alpha.10",
                 .description = "Consensus spec tests version tag.",
             },
             .spec_test_out_dir = .{

--- a/src/state_transition/block/process_deposit_request.zig
+++ b/src/state_transition/block/process_deposit_request.zig
@@ -6,9 +6,11 @@ const PendingDeposit = types.electra.PendingDeposit.Type;
 const c = @import("constants");
 
 pub fn processDepositRequest(comptime fork: ForkSeq, state: *BeaconState(fork), deposit_request: *const DepositRequest) !void {
-    const deposit_requests_start_index = try state.depositRequestsStartIndex();
-    if (deposit_requests_start_index == c.UNSET_DEPOSIT_REQUESTS_START_INDEX) {
-        try state.setDepositRequestsStartIndex(deposit_request.index);
+    if (comptime fork == .electra) {
+        const deposit_requests_start_index = try state.depositRequestsStartIndex();
+        if (deposit_requests_start_index == c.UNSET_DEPOSIT_REQUESTS_START_INDEX) {
+            try state.setDepositRequestsStartIndex(deposit_request.index);
+        }
     }
 
     const pending_deposit = PendingDeposit{

--- a/test/spec/version.txt
+++ b/test/spec/version.txt
@@ -2,4 +2,4 @@
 // This file exists as a cache key for the spec tests in CI.
 // Do not commit changes by hand.
 
-v1.6.0-beta.2
+v1.7.0-alpha.10


### PR DESCRIPTION
we're integrating stf into lodestar soon, so let's keep the versions in sync.