### PR TITLE
chore: update spec test version to v1.7.0-alpha.11

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -105,7 +105,7 @@
             },
             .spec_test_version = .{
                 .type = .string,
-                .default = "v1.7.0-alpha.10",
+                .default = "v1.7.0-alpha.11",
                 .description = "Consensus spec tests version tag.",
             },
             .spec_test_out_dir = .{

--- a/test/spec/version.txt
+++ b/test/spec/version.txt
@@ -2,4 +2,4 @@
 // This file exists as a cache key for the spec tests in CI.
 // Do not commit changes by hand.
 
-v1.7.0-alpha.10
+v1.7.0-alpha.11


### PR DESCRIPTION
Bumps the consensus spec tests from `v1.7.0-alpha.10` to `v1.7.0-alpha.11`.

Closes #443.

### Changes
- `build.zig.zon`: bump `spec_test_version` default to `v1.7.0-alpha.11`
- `test/spec/version.txt`: updated version (changed by the spec-test download step, not hand edited)

### Notes
- Unblocked by ChainSafe/lodestar#9541 (alpha.11 spec upgrade), now merged — lodestar and lodestar-z are aligned on the same spec test version.
- All spec tests pass locally against alpha.11.
- The pre-gloas spec refactors @ensi321 flagged in [#441 (comment)](https://github.com/ChainSafe/lodestar-z/pull/441#pullrequestreview-4549229396) don't surface as test failures. Leaving those alignments as a separate follow-up rather than folding them into this bump though I can also fold them in here if needed.