### PR TITLE
feat: add `state.getBuildersLength()` binding

### DIFF
--- a/bindings/napi/BeaconStateView.zig
+++ b/bindings/napi/BeaconStateView.zig
@@ -723,6 +723,13 @@ pub fn getAllValidators(self: *const BeaconStateView) !js.Array {
     return js_types.wrap(js.Array, result);
 }
 
+/// Get the number of builders in the registry (Gloas+). Throws on pre-Gloas states.
+pub fn getBuildersLength(self: *const BeaconStateView) !js.Number {
+    const cached_state = try self.requireState();
+    const count = try cached_state.state.buildersLength();
+    return js.Number.from(count);
+}
+
 /// Get all balances in the registry.
 pub fn getAllBalances(self: *const BeaconStateView) !js.Array {
     const env = js.env();

--- a/bindings/src/index.d.ts
+++ b/bindings/src/index.d.ts
@@ -269,6 +269,7 @@ export declare class BeaconStateView {
   getBalance(index: number): number;
   getValidator(index: number): Validator;
   getAllValidators(): Validator[];
+  getBuildersLength(): number;
   getAllBalances(): number[];
   getValidatorsByStatus(statuses: Set<string>, currentEpoch: number): Validator[];
   // TODO wrong function

--- a/bindings/test/beaconStateView.test.ts
+++ b/bindings/test/beaconStateView.test.ts
@@ -450,6 +450,12 @@ describe("BeaconStateView", () => {
     });
   });
 
+  describe("gloas+ fields", () => {
+    it("getBuildersLength should throw on a pre-Gloas state", () => {
+      expect(() => state.getBuildersLength()).toThrow();
+    });
+  });
+
   describe("block and state roots", () => {
     it("getBlockRoot should return 32 bytes", () => {
       const blockRoot = state.getBlockRoot(state.epoch - 1);

--- a/src/fork_types/any_beacon_state.zig
+++ b/src/fork_types/any_beacon_state.zig
@@ -382,6 +382,16 @@ pub const AnyBeaconState = union(ForkSeq) {
         try self.setEth1DepositIndex(try self.eth1DepositIndex() + 1);
     }
 
+    pub fn buildersLength(self: *AnyBeaconState) !usize {
+        return switch (self.*) {
+            .phase0, .altair, .bellatrix, .capella, .deneb, .electra, .fulu => error.InvalidAtFork,
+            inline else => |state| {
+                var builders_view = try state.getReadonly("builders");
+                return builders_view.length();
+            },
+        };
+    }
+
     pub fn validators(self: *AnyBeaconState) !*ct.phase0.Validators.TreeView {
         return switch (self.*) {
             inline else => |state| try state.get("validators"),


### PR DESCRIPTION
## Description

Introduces `state.getBuildersLength()` binding.
Function placement reflects the one present in `nativeBeaconStateView.ts` (ChainSafe/lodestar#9593).

Closes #470 

Used Claude to audit changes.