### PR TITLE
chore: rename era shortHistoricalRoot to shortEraRoot

### DIFF
--- a/src/era/Reader.zig
+++ b/src/era/Reader.zig
@@ -16,8 +16,8 @@ file: std.Io.File,
 io: std.Io,
 /// The era number retrieved from the file name
 era_number: u64,
-/// The short historical root retrieved from the file name
-short_historical_root: [8]u8,
+/// The short era root retrieved from the file name
+short_era_root: [8]u8,
 /// An array of state and block indices, one per group
 group_indices: []era.GroupIndex,
 /// Persistent merkle tree pool used by TreeViews (must outlive returned views)
@@ -49,7 +49,7 @@ pub fn open(allocator: std.mem.Allocator, io: std.Io, config: c.BeaconConfig, pa
         .file = file,
         .io = io,
         .era_number = era_file_name.era_number,
-        .short_historical_root = era_file_name.short_historical_root,
+        .short_era_root = era_file_name.short_era_root,
         .group_indices = group_indices,
         .pool = pool,
     };

--- a/src/era/Writer.zig
+++ b/src/era/Writer.zig
@@ -38,7 +38,7 @@ pub const WriterState = union(enum) {
     finished_group: struct {
         era_number: u64,
         current_offset: u64,
-        short_historical_root: [8]u8,
+        short_era_root: [8]u8,
     },
 };
 
@@ -72,7 +72,7 @@ pub fn finish(self: *Writer, allocator: std.mem.Allocator, io: std.Io) ![]const 
     const new_base = try std.fmt.allocPrint(
         allocator,
         "{s}-{d:0>5}-{s}.era",
-        .{ self.config.chain.CONFIG_NAME, self.era_number, self.state.finished_group.short_historical_root },
+        .{ self.config.chain.CONFIG_NAME, self.era_number, self.state.finished_group.short_era_root },
     );
     defer allocator.free(new_base);
 
@@ -120,7 +120,7 @@ pub fn writeVersion(self: *Writer, allocator: std.mem.Allocator) !void {
     };
 }
 
-pub fn writeCompressedState(self: *Writer, allocator: std.mem.Allocator, slot: u64, short_historical_root: [8]u8, data: []const u8) !void {
+pub fn writeCompressedState(self: *Writer, allocator: std.mem.Allocator, slot: u64, short_era_root: [8]u8, data: []const u8) !void {
     if (self.state == .init_group) {
         try self.writeVersion(allocator);
     }
@@ -184,24 +184,24 @@ pub fn writeCompressedState(self: *Writer, allocator: std.mem.Allocator, slot: u
         .finished_group = .{
             .era_number = wg_era_number,
             .current_offset = wg_current_offset,
-            .short_historical_root = short_historical_root,
+            .short_era_root = short_era_root,
         },
     };
 }
 
-pub fn writeSerializedState(self: *Writer, allocator: std.mem.Allocator, slot: u64, short_historical_root: [8]u8, data: []const u8) !void {
+pub fn writeSerializedState(self: *Writer, allocator: std.mem.Allocator, slot: u64, short_era_root: [8]u8, data: []const u8) !void {
     const compressed = try snappy.compress(allocator, data);
     defer allocator.free(compressed);
-    try self.writeCompressedState(allocator, slot, short_historical_root, compressed);
+    try self.writeCompressedState(allocator, slot, short_era_root, compressed);
 }
 
 pub fn writeState(self: *Writer, allocator: std.mem.Allocator, state: fork_types.AnyBeaconState) !void {
     var s = state;
     const slot = try s.slot();
-    const short_historical_root = try era.getShortHistoricalRoot(state);
+    const short_era_root = try era.getShortEraRoot(state);
     const serialized = try state.serialize(allocator);
     defer allocator.free(serialized);
-    try self.writeSerializedState(allocator, slot, short_historical_root, serialized);
+    try self.writeSerializedState(allocator, slot, short_era_root, serialized);
 }
 
 pub fn writeCompressedBlock(self: *Writer, allocator: std.mem.Allocator, slot: u64, data: []const u8) !void {

--- a/src/era/era.zig
+++ b/src/era/era.zig
@@ -4,11 +4,11 @@ const fork_types = @import("fork_types");
 const e2s = @import("e2s.zig");
 
 /// Parsed components of an .era file name.
-/// Format: <config-name>-<era-number>-<short-historical-root>.era
+/// Format: <config-name>-<era-number>-<short-era-root>.era
 pub const EraFileName = struct {
     config_name: []const u8,
     era_number: u64,
-    short_historical_root: [8]u8,
+    short_era_root: [8]u8,
 
     pub fn parse(path: []const u8) (error{InvalidEraFileName} || std.fmt.ParseIntError)!EraFileName {
         if (!std.mem.endsWith(u8, path, ".era")) {
@@ -17,16 +17,16 @@ pub const EraFileName = struct {
         var it = std.mem.splitScalar(u8, std.fs.path.stem(path), '-');
         const config_name = it.next() orelse return error.InvalidEraFileName;
         const era_number = try std.fmt.parseUnsigned(u64, it.next() orelse return error.InvalidEraFileName, 10);
-        var short_historical_root: [8]u8 = undefined;
-        const maybe_short_historical_root = it.next() orelse return error.InvalidEraFileName;
-        if (maybe_short_historical_root.len != 8) {
+        var short_era_root: [8]u8 = undefined;
+        const maybe_short_era_root = it.next() orelse return error.InvalidEraFileName;
+        if (maybe_short_era_root.len != 8) {
             return error.InvalidEraFileName;
         }
-        @memcpy(&short_historical_root, maybe_short_historical_root);
+        @memcpy(&short_era_root, maybe_short_era_root);
         return .{
             .config_name = config_name,
             .era_number = era_number,
-            .short_historical_root = short_historical_root,
+            .short_era_root = short_era_root,
         };
     }
 };
@@ -121,29 +121,29 @@ pub fn computeStartBlockSlotFromEraNumber(era_number: u64) !u64 {
     return (try std.math.sub(u64, era_number, 1)) * preset.SLOTS_PER_HISTORICAL_ROOT;
 }
 
-pub fn getShortHistoricalRoot(state: fork_types.AnyBeaconState) ![8]u8 {
+pub fn getShortEraRoot(state: fork_types.AnyBeaconState) ![8]u8 {
     const allocator = std.heap.page_allocator;
-    var short_historical_root: [8]u8 = undefined;
+    var short_era_root: [8]u8 = undefined;
     var s = state;
-    var historical_root: [32]u8 = undefined;
+    var era_root: [32]u8 = undefined;
     if (try s.slot() == 0) {
-        historical_root = (try s.genesisValidatorsRoot()).*;
+        era_root = (try s.genesisValidatorsRoot()).*;
     } else if (s.forkSeq().gte(.capella)) {
         var summaries = try s.historicalSummaries();
         const len = try summaries.length();
         if (len == 0) return error.EmptyHistoricalSummaries;
         var last = try summaries.get(len - 1);
-        historical_root = (try last.hashTreeRoot()).*;
+        era_root = (try last.hashTreeRoot()).*;
     } else {
         var roots = try s.historicalRoots();
         const len = try roots.length();
         if (len == 0) return error.EmptyHistoricalRoots;
         var last = try roots.get(len - 1);
-        try last.toValue(allocator, &historical_root);
+        try last.toValue(allocator, &era_root);
     }
 
-    _ = try std.fmt.bufPrint(&short_historical_root, "{x}", .{historical_root[0..4]});
-    return short_historical_root;
+    _ = try std.fmt.bufPrint(&short_era_root, "{x}", .{era_root[0..4]});
+    return short_era_root;
 }
 
 // ── Unit tests ──────────────────────────────────────────────────────────
@@ -152,13 +152,13 @@ test "EraFileName.parse - valid filename" {
     const result = try EraFileName.parse("mainnet-00001-a1b2c3d4.era");
     try std.testing.expectEqualStrings("mainnet", result.config_name);
     try std.testing.expectEqual(@as(u64, 1), result.era_number);
-    try std.testing.expectEqualStrings("a1b2c3d4", &result.short_historical_root);
+    try std.testing.expectEqualStrings("a1b2c3d4", &result.short_era_root);
 }
 
 test "EraFileName.parse - large era number" {
     const result = try EraFileName.parse("mainnet-99999-deadbeef.era");
     try std.testing.expectEqual(@as(u64, 99999), result.era_number);
-    try std.testing.expectEqualStrings("deadbeef", &result.short_historical_root);
+    try std.testing.expectEqualStrings("deadbeef", &result.short_era_root);
 }
 
 test "EraFileName.parse - different config names" {

--- a/test/int/era/root.zig
+++ b/test/int/era/root.zig
@@ -83,7 +83,7 @@ test "write an era file from an existing era file" {
     if (out_reader.era_number != reader.era_number) {
         return error.IncorrectWrittenEraNumber;
     }
-    if (!std.mem.eql(u8, &reader.short_historical_root, &out_reader.short_historical_root)) {
+    if (!std.mem.eql(u8, &reader.short_era_root, &out_reader.short_era_root)) {
         return error.IncorrectWrittenShortHistoricalRoot;
     }
 


### PR DESCRIPTION
Make era-library compliant with the eth2-client-store specification:
https://github.com/eth-clients/e2store-format-specs/pull/17

Equivalent change in lodestar has already been merged:
https://github.com/ChainSafe/lodestar/pull/9585

Testing:

`zig build `succeeds.
`pnpm run lint` passes.
`pnpm run test` passes.

AI Disclosure: 

This is a easier refactoring change so no AI was used here,