### PR TITLE
fix(bls): align PublicKey.uncompress validation with Signature.uncompress

### DIFF
--- a/src/bls/PublicKey.zig
+++ b/src/bls/PublicKey.zig
@@ -114,7 +114,7 @@ test uncompress {
 
     // Invalid lengths must be rejected, even with the compression bit set.
     try std.testing.expectError(BlstError.BadEncoding, uncompress(&[_]u8{}));
-    try std.testing.expectError(BlstError.BadEncoding, uncompress(pk_comp[0..COMPRESS_SIZE - 1]));
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(pk_comp[0 .. COMPRESS_SIZE - 1]));
     var too_long = [_]u8{0} ** (COMPRESS_SIZE + 1);
     @memcpy(too_long[0..COMPRESS_SIZE], &pk_comp);
     try std.testing.expectError(BlstError.BadEncoding, uncompress(&too_long));

--- a/src/bls/PublicKey.zig
+++ b/src/bls/PublicKey.zig
@@ -61,7 +61,7 @@ pub fn serialize(self: *const Self) [SERIALIZE_SIZE]u8 {
 ///
 /// Returns the `PublicKey` on success, `BlstError` on failure.
 pub fn uncompress(pk_comp: []const u8) BlstError!Self {
-    if (pk_comp.len == COMPRESS_SIZE or (pk_comp[0] & 0x80) != 0) {
+    if (pk_comp.len == COMPRESS_SIZE and (pk_comp[0] & 0x80) != 0) {
         var pk = Self{};
         try errorFromInt(c.blst_p1_uncompress(&pk.point, pk_comp.ptr));
         return pk;
@@ -93,5 +93,34 @@ const std = @import("std");
 const BlstError = @import("error.zig").BlstError;
 const errorFromInt = @import("error.zig").errorFromInt;
 const AggregatePublicKey = @import("AggregatePublicKey.zig");
+const SecretKey = @import("SecretKey.zig");
 
 const c = @import("root.zig").c;
+
+test uncompress {
+    const ikm: [32]u8 = [_]u8{
+        0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
+        0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
+        0x60, 0x5b, 0xb0, 0x56, 0xed, 0xfe, 0x2b, 0x60, 0xa6, 0x3c,
+        0x48, 0x99,
+    };
+    const sk = try SecretKey.keyGen(&ikm, null);
+    const pk = sk.toPublicKey();
+    const pk_comp = pk.compress();
+
+    // Valid compressed bytes round-trip.
+    const pk_uncomp = try uncompress(&pk_comp);
+    try std.testing.expect(pk.isEqual(&pk_uncomp));
+
+    // Invalid lengths must be rejected, even with the compression bit set.
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(&[_]u8{}));
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(pk_comp[0..COMPRESS_SIZE - 1]));
+    var too_long = [_]u8{0} ** (COMPRESS_SIZE + 1);
+    @memcpy(too_long[0..COMPRESS_SIZE], &pk_comp);
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(&too_long));
+
+    // Correct length without the compression bit must be rejected.
+    var no_comp_bit = pk_comp;
+    no_comp_bit[0] &= 0x7f;
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(&no_comp_bit));
+}

--- a/src/bls/Signature.zig
+++ b/src/bls/Signature.zig
@@ -222,15 +222,37 @@ const Pairing = @import("Pairing.zig");
 
 const SecretKey = @import("SecretKey.zig");
 const DST = @import("root.zig").DST;
+const ikm: [32]u8 = [_]u8{
+    0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
+    0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
+    0x60, 0x5b, 0xb0, 0x56, 0xed, 0xfe, 0x2b, 0x60, 0xa6, 0x3c,
+    0x48, 0x99,
+};
+
+test uncompress {
+    const sk = try SecretKey.keyGen(&ikm, null);
+    const sig = sk.sign("hello foo", DST, null);
+    const sig_comp = sig.compress();
+
+    // Valid compressed bytes round-trip.
+    const sig_uncomp = try uncompress(&sig_comp);
+    try std.testing.expect(sig.isEqual(&sig_uncomp));
+
+    // Invalid lengths must be rejected, even with the compression bit set.
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(&[_]u8{}));
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(sig_comp[0 .. COMPRESS_SIZE - 1]));
+    var too_long = [_]u8{0} ** (COMPRESS_SIZE + 1);
+    @memcpy(too_long[0..COMPRESS_SIZE], &sig_comp);
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(&too_long));
+
+    // Correct length without the compression bit must be rejected.
+    var no_comp_bit = sig_comp;
+    no_comp_bit[0] &= 0x7f;
+    try std.testing.expectError(BlstError.BadEncoding, uncompress(&no_comp_bit));
+}
 
 test "test_sign_n_verify" {
     // sample code for consumer like on Readme
-    const ikm: [32]u8 = [_]u8{
-        0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
-        0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
-        0x60, 0x5b, 0xb0, 0x56, 0xed, 0xfe, 0x2b, 0x60, 0xa6, 0x3c,
-        0x48, 0x99,
-    };
     const sk = try SecretKey.keyGen(&ikm, null);
     const pk = sk.toPublicKey();
 
@@ -250,13 +272,6 @@ test "test_sign_n_verify" {
 }
 
 test aggregateVerify {
-    const ikm: [32]u8 = [_]u8{
-        0x93, 0xad, 0x7e, 0x65, 0xde, 0xad, 0x05, 0x2a, 0x08, 0x3a,
-        0x91, 0x0c, 0x8b, 0x72, 0x85, 0x91, 0x46, 0x4c, 0xca, 0x56,
-        0x60, 0x5b, 0xb0, 0x56, 0xed, 0xfe, 0x2b, 0x60, 0xa6, 0x3c,
-        0x48, 0x99,
-    };
-
     const dst = DST;
     // aug is null
 


### PR DESCRIPTION
closes #501

see https://github.com/supranational/blst/blob/master/bindings/rust/src/lib.rs#L857