### PR TITLE
fix(bindings): validate class types before unwrap

### DIFF
--- a/bindings/napi/blst.zig
+++ b/bindings/napi/blst.zig
@@ -87,7 +87,8 @@ fn formatHex(bytes: []const u8) !js.String {
 }
 
 fn unwrapClass(comptime T: type, value: js.Value) !*T {
-    return js.env().unwrap(T, value.toValue());
+    const raw = value.toValue();
+    return js.convertArg(*T, raw.value, raw.env);
 }
 
 /// Reads a Uint8Array slice from a generic `js.Value`.
@@ -484,7 +485,6 @@ pub fn verifyMultipleAggregateSignatures(sets: js.Array, pks_validate: ?js.Boole
     var prng = std.Random.DefaultPrng.init(std.mem.readInt(u64, &seed_bytes, .little));
     const rand = prng.random();
 
-    const e = js.env();
     for (0..n_elems) |i| {
         const set = (try sets.get(@intCast(i))).toValue();
 
@@ -494,11 +494,11 @@ pub fn verifyMultipleAggregateSignatures(sets: js.Array, pks_validate: ?js.Boole
         msgs[i] = msg_bytes;
 
         const pk_napi = try set.getNamedProperty("pk");
-        const wrapped_pk = try e.unwrap(PublicKey, pk_napi);
+        const wrapped_pk = try unwrapClass(PublicKey, .{ .val = pk_napi });
         pks[i] = &wrapped_pk.raw;
 
         const sig_napi = try set.getNamedProperty("sig");
-        const wrapped_sig = try e.unwrap(Signature, sig_napi);
+        const wrapped_sig = try unwrapClass(Signature, .{ .val = sig_napi });
         sigs[i] = &wrapped_sig.raw;
 
         var scalar = rand.int(u64);
@@ -632,7 +632,7 @@ pub fn aggregateWithRandomness(sets: js.Array) !js.Value {
         const set = (try sets.get(@intCast(i))).toValue();
 
         const pk_napi = try set.getNamedProperty("pk");
-        const wrapped_pk = try env.unwrap(PublicKey, pk_napi);
+        const wrapped_pk = try unwrapClass(PublicKey, .{ .val = pk_napi });
         pk_ptrs[i] = &wrapped_pk.raw;
 
         const sig_napi = try set.getNamedProperty("sig");
@@ -828,7 +828,7 @@ pub fn asyncAggregateWithRandomness(sets: js.Array) !js.Value {
         const set = (try sets.get(@intCast(i))).toValue();
 
         const pk_napi = try set.getNamedProperty("pk");
-        const wrapped_pk = try env.unwrap(PublicKey, pk_napi);
+        const wrapped_pk = try unwrapClass(PublicKey, .{ .val = pk_napi });
         data.pks[i] = wrapped_pk.raw;
         data.pk_ptrs[i] = &data.pks[i];
 

--- a/bindings/test/blst.test.ts
+++ b/bindings/test/blst.test.ts
@@ -122,6 +122,16 @@ describe("blst", () => {
     it("should throw on invalid length", () => {
       expect(() => Signature.fromBytes(new Uint8Array(95))).toThrow();
     });
+
+    it("should reject PublicKey objects when aggregating", () => {
+      const pk = PublicKey.fromHex(TEST_VECTORS.publicKey.compressed);
+      expect(() => Signature.aggregate([pk as unknown as Signature], false)).toThrow("TypeMismatch");
+    });
+
+    it("should aggregate Signature objects", () => {
+      const signatures = getTestSets(2).map((set) => set.sig);
+      expect(Signature.aggregate(signatures, false)).toBeInstanceOf(Signature);
+    });
   });
 
   describe("SecretKey", () => {
@@ -285,6 +295,23 @@ describe("blst", () => {
       sets[0].sig = sets[1].sig;
       expect(verifyMultipleAggregateSignatures(sets, false, false)).to.be.false;
     });
+
+    it("should reject objects of the wrong class", () => {
+      const [{msg, pk, sig, sk}] = getTestSets(1);
+      expect(() =>
+        verifyMultipleAggregateSignatures([{msg, pk: sk as unknown as PublicKey, sig}], false, false)
+      ).toThrow("TypeMismatch");
+      expect(() =>
+        verifyMultipleAggregateSignatures([{msg, pk, sig: pk as unknown as Signature}], false, false)
+      ).toThrow("TypeMismatch");
+    });
+  });
+
+  describe("aggregatePublicKeys", () => {
+    it("should reject SecretKey objects", () => {
+      const sk = SecretKey.fromBytes(SECRET_KEY_BYTES);
+      expect(() => aggregatePublicKeys([sk as unknown as PublicKey])).toThrow("TypeMismatch");
+    });
   });
 
   describe("aggregateSerializedPublicKeys", () => {
@@ -369,6 +396,12 @@ describe("blst", () => {
       input[2].sig = new Uint8Array(96).fill(0xff);
       expect(() => aggregateWithRandomness(input)).toThrow();
     });
+
+    it("should reject objects of the wrong class", () => {
+      const {sets} = getTestSetsSameMessage(1);
+      const input = [{pk: sets[0].sk as unknown as PublicKey, sig: sets[0].sig.toBytes()}];
+      expect(() => aggregateWithRandomness(input)).toThrow("TypeMismatch");
+    });
   });
 
   describe("asyncAggregateWithRandomness", () => {
@@ -443,6 +476,12 @@ describe("blst", () => {
       const input = sets.map((s) => ({pk: s.pk, sig: s.sig.toBytes()}));
       input[2].sig = new Uint8Array(96).fill(0xff);
       await expect(Promise.resolve().then(() => asyncAggregateWithRandomness(input))).rejects.toThrow();
+    });
+
+    it("should reject objects of the wrong class", async () => {
+      const {sets} = getTestSetsSameMessage(1);
+      const input = [{pk: sets[0].sk as unknown as PublicKey, sig: sets[0].sig.toBytes()}];
+      await expect(Promise.resolve().then(() => asyncAggregateWithRandomness(input))).rejects.toThrow("TypeMismatch");
     });
 
     it("should resolve concurrent invocations correctly", async () => {

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -40,8 +40,8 @@
             .hash = "zig_yaml-0.1.0-C1161kFWAwDxjKAFmklKwWVDvz2mmq0Q__bDhGGjeyd3",
         },
         .zapi = .{
-            .url = "https://github.com/ChainSafe/zapi/archive/refs/tags/zapi-v3.1.0.tar.gz",
-            .hash = "zapi-3.1.0-rIqzUQJsBADCFUrmxoTZyOhSTkcW6m3t_OgOHc6oxnm9",
+            .url = "https://github.com/ChainSafe/zapi/archive/9dd211167c4774c5a79e3d6fd360c22adca0a138.tar.gz",
+            .hash = "zapi-3.1.0-rIqzUQtsBADx3WYJ6Fe4BY1M3Q6zGpsti2B_cvgxZgto",
         },
         .zbench = .{
             .url = "git+https://github.com/hendriknielaender/zBench#b2b89c475e3ef1bb2bd71255c80478a82d3e0ca8",


### PR DESCRIPTION
## Summary

- route every BLST class extraction through zapi typed conversion so N-API type tags are checked before `napi_unwrap`
- pin zapi to the merge commit of [ChainSafe/zapi#50](https://github.com/ChainSafe/zapi/pull/50) until the pointer-argument fix is released
- add regression coverage for wrong-class values across signature/public-key aggregation and randomized verification paths

## Motivation

Raw `Env.unwrap` accepts any wrapped N-API object. Passing a `SecretKey` where a `PublicKey` or `Signature` is expected can therefore reinterpret a smaller native allocation as a larger structure and read beyond its bounds.