### PR TITLE
chore: remove stale epoch cache TODOs

### DIFF
--- a/src/state_transition/cache/epoch_cache.zig
+++ b/src/state_transition/cache/epoch_cache.zig
@@ -99,9 +99,6 @@ pub const EpochCache = struct {
 
     next_shuffling: *EpochShufflingRc,
 
-    // TODO: not needed, maybe just get from the next shuffling?
-    // next_active_indices
-
     // EpochCache does not take ownership of EffectiveBalanceIncrements, it is shared across EpochCache instances
     effective_balance_increments: *EffectiveBalanceIncrementsRc,
 
@@ -722,12 +719,6 @@ pub const EpochCache = struct {
         return error.EpochTooFar;
     }
 
-    // TODO: getBeaconProposers - can access directly?
-
-    // TODO: getBeaconProposersNextEpoch - may not needed post-fulu
-
-    // TODO: do we need getBeaconCommittees? in validateAttestationElectra we do a for loop over committee_indices and call getBeaconProposer() instead
-
     /// consumer takes ownership of the returned indexed attestation
     /// hence it needs to deinit attesting_indices inside
     pub fn computeIndexedAttestationPhase0(self: *const EpochCache, attestation: *const types.phase0.Attestation.Type, out: *types.phase0.IndexedAttestation.Type) !void {
@@ -853,7 +844,6 @@ pub const EpochCache = struct {
         }
     }
 
-    // TODO: getBeaconCommittee
     pub fn getShufflingAtSlotOrNull(self: *const EpochCache, slot: Slot) ?*const EpochShuffling {
         const epoch = computeEpochAtSlot(slot);
         return self.getShufflingAtEpochOrNull(epoch);

--- a/src/state_transition/cache/epoch_transition_cache.zig
+++ b/src/state_transition/cache/epoch_transition_cache.zig
@@ -58,7 +58,6 @@ const ReusedEpochTransitionCache = struct {
 
     flags: U8Array,
 
-    // TODO: nextShufflingDecisionRoot, is it necessary without ShufflingCache?
     next_epoch_shuffling_active_validator_indices: std.ArrayList(ValidatorIndex),
 
     is_compounding_validator_arr: BoolArray,
@@ -203,15 +202,12 @@ pub const EpochTransitionCache = struct {
     slashing_penalties: []u64,
     balances: ?U64Array,
     next_shuffling_active_indices: []const ValidatorIndex,
-    // TODO: nextShufflingDecisionRoot may not needed as we don't use ShufflingCache
     next_epoch_total_active_balance_by_increment: u64,
-    // TODO: asyncShufflingCalculation may not needed as we don't use ShufflingCache
     // these are borrowed from ReusedEpochTransitionCache
     is_active_prev_epoch: []const bool,
     is_active_curr_epoch: []const bool,
     is_active_next_epoch: []const bool,
 
-    // TODO: no need EpochTransitionCacheOpts for zig version
     // this is the same to beforeProcessEpoch in typesript version
     pub fn init(
         allocator: Allocator,


### PR DESCRIPTION
## Summary

- remove 14 stale TODO/comment lines from the epoch cache modules
- keep the remaining actionable TODOs unchanged
- make no runtime or API changes

Follow-up to the request in #278.

## Verification

- `zig fmt --check src`
- `zig build test:state_transition`
- `pnpm lint` (passes with pre-existing warnings)
- `git diff --check`

The full `zig build test` was also attempted locally. It is blocked in this environment by missing generated spec-test sources and unsupported `io_uring` for clock tests; the targeted state-transition suite passes.
